### PR TITLE
feat: add user details for getUser call

### DIFF
--- a/appidmanagementv4/app_id_management_v4.go
+++ b/appidmanagementv4/app_id_management_v4.go
@@ -32,6 +32,7 @@ import (
 
 	common "github.com/IBM/appid-management-go-sdk/common"
 	"github.com/IBM/go-sdk-core/v5/core"
+	"github.com/go-openapi/strfmt"
 )
 
 // AppIDManagementV4 : You can use the following APIs to configure your instances of IBM Cloud App ID. To define fine
@@ -822,12 +823,12 @@ func (appIdManagement *AppIDManagementV4) ListCloudDirectoryUsersWithContext(ctx
 // new Cloud Directory user use the  <a href="/swagger-ui/#/Management API - Cloud Directory Workflows/mgmt.startSignUp"
 // target="_blank">sign_up</a> API. <a href="https://cloud.ibm.com/docs/appid?topic=appid-cloud-directory"
 // target="_blank">Learn more</a>.
-func (appIdManagement *AppIDManagementV4) CreateCloudDirectoryUser(createCloudDirectoryUserOptions *CreateCloudDirectoryUserOptions) (response *core.DetailedResponse, err error) {
+func (appIdManagement *AppIDManagementV4) CreateCloudDirectoryUser(createCloudDirectoryUserOptions *CreateCloudDirectoryUserOptions) (result *GetUser, response *core.DetailedResponse, err error) {
 	return appIdManagement.CreateCloudDirectoryUserWithContext(context.Background(), createCloudDirectoryUserOptions)
 }
 
 // CreateCloudDirectoryUserWithContext is an alternate form of the CreateCloudDirectoryUser method which supports a Context parameter
-func (appIdManagement *AppIDManagementV4) CreateCloudDirectoryUserWithContext(ctx context.Context, createCloudDirectoryUserOptions *CreateCloudDirectoryUserOptions) (response *core.DetailedResponse, err error) {
+func (appIdManagement *AppIDManagementV4) CreateCloudDirectoryUserWithContext(ctx context.Context, createCloudDirectoryUserOptions *CreateCloudDirectoryUserOptions) (result *GetUser, response *core.DetailedResponse, err error) {
 	err = core.ValidateNotNil(createCloudDirectoryUserOptions, "createCloudDirectoryUserOptions cannot be nil")
 	if err != nil {
 		return
@@ -870,8 +871,17 @@ func (appIdManagement *AppIDManagementV4) CreateCloudDirectoryUserWithContext(ct
 	if createCloudDirectoryUserOptions.Active != nil {
 		body["active"] = createCloudDirectoryUserOptions.Active
 	}
+	if createCloudDirectoryUserOptions.LockedUntil != nil {
+		body["lockedUntil"] = createCloudDirectoryUserOptions.LockedUntil
+	}
+	if createCloudDirectoryUserOptions.DisplayName != nil {
+		body["displayName"] = createCloudDirectoryUserOptions.DisplayName
+	}
 	if createCloudDirectoryUserOptions.UserName != nil {
 		body["userName"] = createCloudDirectoryUserOptions.UserName
+	}
+	if createCloudDirectoryUserOptions.Status != nil {
+		body["status"] = createCloudDirectoryUserOptions.Status
 	}
 	_, err = builder.SetBodyContentJSON(body)
 	if err != nil {
@@ -883,7 +893,18 @@ func (appIdManagement *AppIDManagementV4) CreateCloudDirectoryUserWithContext(ct
 		return
 	}
 
-	response, err = appIdManagement.Service.Request(request, nil)
+	var rawResponse map[string]json.RawMessage
+	response, err = appIdManagement.Service.Request(request, &rawResponse)
+	if err != nil {
+		return
+	}
+	if rawResponse != nil {
+		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalGetUser)
+		if err != nil {
+			return
+		}
+		response.Result = result
+	}
 
 	return
 }
@@ -891,12 +912,12 @@ func (appIdManagement *AppIDManagementV4) CreateCloudDirectoryUserWithContext(ct
 // GetCloudDirectoryUser : Get a Cloud Directory user
 // Returns the requested Cloud Directory user object. <a
 // href="https://cloud.ibm.com/docs/appid?topic=appid-cloud-directory" target="_blank">Learn more</a>.
-func (appIdManagement *AppIDManagementV4) GetCloudDirectoryUser(getCloudDirectoryUserOptions *GetCloudDirectoryUserOptions) (response *core.DetailedResponse, err error) {
+func (appIdManagement *AppIDManagementV4) GetCloudDirectoryUser(getCloudDirectoryUserOptions *GetCloudDirectoryUserOptions) (result *GetUser, response *core.DetailedResponse, err error) {
 	return appIdManagement.GetCloudDirectoryUserWithContext(context.Background(), getCloudDirectoryUserOptions)
 }
 
 // GetCloudDirectoryUserWithContext is an alternate form of the GetCloudDirectoryUser method which supports a Context parameter
-func (appIdManagement *AppIDManagementV4) GetCloudDirectoryUserWithContext(ctx context.Context, getCloudDirectoryUserOptions *GetCloudDirectoryUserOptions) (response *core.DetailedResponse, err error) {
+func (appIdManagement *AppIDManagementV4) GetCloudDirectoryUserWithContext(ctx context.Context, getCloudDirectoryUserOptions *GetCloudDirectoryUserOptions) (result *GetUser, response *core.DetailedResponse, err error) {
 	err = core.ValidateNotNil(getCloudDirectoryUserOptions, "getCloudDirectoryUserOptions cannot be nil")
 	if err != nil {
 		return
@@ -934,7 +955,18 @@ func (appIdManagement *AppIDManagementV4) GetCloudDirectoryUserWithContext(ctx c
 		return
 	}
 
-	response, err = appIdManagement.Service.Request(request, nil)
+	var rawResponse map[string]json.RawMessage
+	response, err = appIdManagement.Service.Request(request, &rawResponse)
+	if err != nil {
+		return
+	}
+	if rawResponse != nil {
+		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalGetUser)
+		if err != nil {
+			return
+		}
+		response.Result = result
+	}
 
 	return
 }
@@ -942,12 +974,12 @@ func (appIdManagement *AppIDManagementV4) GetCloudDirectoryUserWithContext(ctx c
 // UpdateCloudDirectoryUser : Update a Cloud Directory user
 // Updates an existing Cloud Directory user. <a href="https://cloud.ibm.com/docs/appid?topic=appid-cd-users"
 // target="_blank">Learn more</a>.
-func (appIdManagement *AppIDManagementV4) UpdateCloudDirectoryUser(updateCloudDirectoryUserOptions *UpdateCloudDirectoryUserOptions) (response *core.DetailedResponse, err error) {
+func (appIdManagement *AppIDManagementV4) UpdateCloudDirectoryUser(updateCloudDirectoryUserOptions *UpdateCloudDirectoryUserOptions) (result *GetUser, response *core.DetailedResponse, err error) {
 	return appIdManagement.UpdateCloudDirectoryUserWithContext(context.Background(), updateCloudDirectoryUserOptions)
 }
 
 // UpdateCloudDirectoryUserWithContext is an alternate form of the UpdateCloudDirectoryUser method which supports a Context parameter
-func (appIdManagement *AppIDManagementV4) UpdateCloudDirectoryUserWithContext(ctx context.Context, updateCloudDirectoryUserOptions *UpdateCloudDirectoryUserOptions) (response *core.DetailedResponse, err error) {
+func (appIdManagement *AppIDManagementV4) UpdateCloudDirectoryUserWithContext(ctx context.Context, updateCloudDirectoryUserOptions *UpdateCloudDirectoryUserOptions) (result *GetUser, response *core.DetailedResponse, err error) {
 	err = core.ValidateNotNil(updateCloudDirectoryUserOptions, "updateCloudDirectoryUserOptions cannot be nil")
 	if err != nil {
 		return
@@ -985,14 +1017,23 @@ func (appIdManagement *AppIDManagementV4) UpdateCloudDirectoryUserWithContext(ct
 	if updateCloudDirectoryUserOptions.Emails != nil {
 		body["emails"] = updateCloudDirectoryUserOptions.Emails
 	}
-	if updateCloudDirectoryUserOptions.Active != nil {
-		body["active"] = updateCloudDirectoryUserOptions.Active
+	if updateCloudDirectoryUserOptions.Status != nil {
+		body["status"] = updateCloudDirectoryUserOptions.Status
+	}
+	if updateCloudDirectoryUserOptions.DisplayName != nil {
+		body["displayName"] = updateCloudDirectoryUserOptions.DisplayName
 	}
 	if updateCloudDirectoryUserOptions.UserName != nil {
 		body["userName"] = updateCloudDirectoryUserOptions.UserName
 	}
 	if updateCloudDirectoryUserOptions.Password != nil {
 		body["password"] = updateCloudDirectoryUserOptions.Password
+	}
+	if updateCloudDirectoryUserOptions.Active != nil {
+		body["active"] = updateCloudDirectoryUserOptions.Active
+	}
+	if updateCloudDirectoryUserOptions.LockedUntil != nil {
+		body["lockedUntil"] = updateCloudDirectoryUserOptions.LockedUntil
 	}
 	_, err = builder.SetBodyContentJSON(body)
 	if err != nil {
@@ -1004,7 +1045,18 @@ func (appIdManagement *AppIDManagementV4) UpdateCloudDirectoryUserWithContext(ct
 		return
 	}
 
-	response, err = appIdManagement.Service.Request(request, nil)
+	var rawResponse map[string]json.RawMessage
+	response, err = appIdManagement.Service.Request(request, &rawResponse)
+	if err != nil {
+		return
+	}
+	if rawResponse != nil {
+		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalGetUser)
+		if err != nil {
+			return
+		}
+		response.Result = result
+	}
 
 	return
 }
@@ -1319,12 +1371,12 @@ func (appIdManagement *AppIDManagementV4) CloudDirectoryGetUserinfoWithContext(c
 // StartSignUp : Sign up
 // Start the sign up process <a href="https://cloud.ibm.com/docs/appid?topic=appid-branded" target="_blank">Learn
 // more</a>.
-func (appIdManagement *AppIDManagementV4) StartSignUp(startSignUpOptions *StartSignUpOptions) (response *core.DetailedResponse, err error) {
+func (appIdManagement *AppIDManagementV4) StartSignUp(startSignUpOptions *StartSignUpOptions) (result *GetUser, response *core.DetailedResponse, err error) {
 	return appIdManagement.StartSignUpWithContext(context.Background(), startSignUpOptions)
 }
 
 // StartSignUpWithContext is an alternate form of the StartSignUp method which supports a Context parameter
-func (appIdManagement *AppIDManagementV4) StartSignUpWithContext(ctx context.Context, startSignUpOptions *StartSignUpOptions) (response *core.DetailedResponse, err error) {
+func (appIdManagement *AppIDManagementV4) StartSignUpWithContext(ctx context.Context, startSignUpOptions *StartSignUpOptions) (result *GetUser, response *core.DetailedResponse, err error) {
 	err = core.ValidateNotNil(startSignUpOptions, "startSignUpOptions cannot be nil")
 	if err != nil {
 		return
@@ -1372,8 +1424,17 @@ func (appIdManagement *AppIDManagementV4) StartSignUpWithContext(ctx context.Con
 	if startSignUpOptions.Active != nil {
 		body["active"] = startSignUpOptions.Active
 	}
+	if startSignUpOptions.LockedUntil != nil {
+		body["lockedUntil"] = startSignUpOptions.LockedUntil
+	}
+	if startSignUpOptions.DisplayName != nil {
+		body["displayName"] = startSignUpOptions.DisplayName
+	}
 	if startSignUpOptions.UserName != nil {
 		body["userName"] = startSignUpOptions.UserName
+	}
+	if startSignUpOptions.Status != nil {
+		body["status"] = startSignUpOptions.Status
 	}
 	_, err = builder.SetBodyContentJSON(body)
 	if err != nil {
@@ -1385,7 +1446,18 @@ func (appIdManagement *AppIDManagementV4) StartSignUpWithContext(ctx context.Con
 		return
 	}
 
-	response, err = appIdManagement.Service.Request(request, nil)
+	var rawResponse map[string]json.RawMessage
+	response, err = appIdManagement.Service.Request(request, &rawResponse)
+	if err != nil {
+		return
+	}
+	if rawResponse != nil {
+		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalGetUser)
+		if err != nil {
+			return
+		}
+		response.Result = result
+	}
 
 	return
 }
@@ -1464,12 +1536,12 @@ func (appIdManagement *AppIDManagementV4) UserVerificationResultWithContext(ctx 
 // StartForgotPassword : Forgot password
 // Starts the forgot password process. <a href="https://cloud.ibm.com/docs/appid?topic=appid-branded"
 // target="_blank">Learn more</a>.
-func (appIdManagement *AppIDManagementV4) StartForgotPassword(startForgotPasswordOptions *StartForgotPasswordOptions) (response *core.DetailedResponse, err error) {
+func (appIdManagement *AppIDManagementV4) StartForgotPassword(startForgotPasswordOptions *StartForgotPasswordOptions) (result *GetUser, response *core.DetailedResponse, err error) {
 	return appIdManagement.StartForgotPasswordWithContext(context.Background(), startForgotPasswordOptions)
 }
 
 // StartForgotPasswordWithContext is an alternate form of the StartForgotPassword method which supports a Context parameter
-func (appIdManagement *AppIDManagementV4) StartForgotPasswordWithContext(ctx context.Context, startForgotPasswordOptions *StartForgotPasswordOptions) (response *core.DetailedResponse, err error) {
+func (appIdManagement *AppIDManagementV4) StartForgotPasswordWithContext(ctx context.Context, startForgotPasswordOptions *StartForgotPasswordOptions) (result *GetUser, response *core.DetailedResponse, err error) {
 	err = core.ValidateNotNil(startForgotPasswordOptions, "startForgotPasswordOptions cannot be nil")
 	if err != nil {
 		return
@@ -1520,7 +1592,18 @@ func (appIdManagement *AppIDManagementV4) StartForgotPasswordWithContext(ctx con
 		return
 	}
 
-	response, err = appIdManagement.Service.Request(request, nil)
+	var rawResponse map[string]json.RawMessage
+	response, err = appIdManagement.Service.Request(request, &rawResponse)
+	if err != nil {
+		return
+	}
+	if rawResponse != nil {
+		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalGetUser)
+		if err != nil {
+			return
+		}
+		response.Result = result
+	}
 
 	return
 }
@@ -1599,12 +1682,12 @@ func (appIdManagement *AppIDManagementV4) ForgotPasswordResultWithContext(ctx co
 // ChangePassword : Change password
 // Changes the Cloud Directory user password. <a href="https://cloud.ibm.com/docs/appid?topic=appid-branded"
 // target="_blank">Learn more</a>.
-func (appIdManagement *AppIDManagementV4) ChangePassword(changePasswordOptions *ChangePasswordOptions) (response *core.DetailedResponse, err error) {
+func (appIdManagement *AppIDManagementV4) ChangePassword(changePasswordOptions *ChangePasswordOptions) (result *GetUser, response *core.DetailedResponse, err error) {
 	return appIdManagement.ChangePasswordWithContext(context.Background(), changePasswordOptions)
 }
 
 // ChangePasswordWithContext is an alternate form of the ChangePassword method which supports a Context parameter
-func (appIdManagement *AppIDManagementV4) ChangePasswordWithContext(ctx context.Context, changePasswordOptions *ChangePasswordOptions) (response *core.DetailedResponse, err error) {
+func (appIdManagement *AppIDManagementV4) ChangePasswordWithContext(ctx context.Context, changePasswordOptions *ChangePasswordOptions) (result *GetUser, response *core.DetailedResponse, err error) {
 	err = core.ValidateNotNil(changePasswordOptions, "changePasswordOptions cannot be nil")
 	if err != nil {
 		return
@@ -1661,7 +1744,18 @@ func (appIdManagement *AppIDManagementV4) ChangePasswordWithContext(ctx context.
 		return
 	}
 
-	response, err = appIdManagement.Service.Request(request, nil)
+	var rawResponse map[string]json.RawMessage
+	response, err = appIdManagement.Service.Request(request, &rawResponse)
+	if err != nil {
+		return
+	}
+	if rawResponse != nil {
+		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalGetUser)
+		if err != nil {
+			return
+		}
+		response.Result = result
+	}
 
 	return
 }
@@ -7230,7 +7324,14 @@ type CreateCloudDirectoryUserOptions struct {
 
 	Active *bool
 
+	LockedUntil *int64
+
+	DisplayName *string
+
 	UserName *string
+
+	// Accepted values "PENDING" or "CONFIRMED".
+	Status *string
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
@@ -7269,9 +7370,27 @@ func (options *CreateCloudDirectoryUserOptions) SetActive(active bool) *CreateCl
 	return options
 }
 
+// SetLockedUntil : Allow user to set LockedUntil
+func (options *CreateCloudDirectoryUserOptions) SetLockedUntil(lockedUntil int64) *CreateCloudDirectoryUserOptions {
+	options.LockedUntil = core.Int64Ptr(lockedUntil)
+	return options
+}
+
+// SetDisplayName : Allow user to set DisplayName
+func (options *CreateCloudDirectoryUserOptions) SetDisplayName(displayName string) *CreateCloudDirectoryUserOptions {
+	options.DisplayName = core.StringPtr(displayName)
+	return options
+}
+
 // SetUserName : Allow user to set UserName
 func (options *CreateCloudDirectoryUserOptions) SetUserName(userName string) *CreateCloudDirectoryUserOptions {
 	options.UserName = core.StringPtr(userName)
+	return options
+}
+
+// SetStatus : Allow user to set Status
+func (options *CreateCloudDirectoryUserOptions) SetStatus(status string) *CreateCloudDirectoryUserOptions {
+	options.Status = core.StringPtr(status)
 	return options
 }
 
@@ -9440,7 +9559,7 @@ type GetUserAndProfileIdentitiesItem struct {
 
 	ID *string `json:"id,omitempty"`
 
-	IDPUserInfo interface{} `json:"idpUserInfo,omitempty"`
+	IDPUserInfo *GetUserAndProfileIdentitiesItemIDPUserInfo `json:"idpUserInfo,omitempty"`
 }
 
 // UnmarshalGetUserAndProfileIdentitiesItem unmarshals an instance of GetUserAndProfileIdentitiesItem from the specified map of raw messages.
@@ -9454,7 +9573,155 @@ func UnmarshalGetUserAndProfileIdentitiesItem(m map[string]json.RawMessage, resu
 	if err != nil {
 		return
 	}
-	err = core.UnmarshalPrimitive(m, "idpUserInfo", &obj.IDPUserInfo)
+	err = core.UnmarshalModel(m, "idpUserInfo", &obj.IDPUserInfo, UnmarshalGetUserAndProfileIdentitiesItemIDPUserInfo)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
+// GetUserAndProfileIdentitiesItemIDPUserInfo : GetUserAndProfileIdentitiesItemIDPUserInfo struct
+type GetUserAndProfileIdentitiesItemIDPUserInfo struct {
+	DisplayName *string `json:"displayName,omitempty"`
+
+	Active *bool `json:"active" validate:"required"`
+
+	LockedUntil *int64 `json:"lockedUntil,omitempty"`
+
+	Emails []GetUserEmailsItem `json:"emails" validate:"required"`
+
+	Meta *GetUserMeta `json:"meta" validate:"required"`
+
+	Schemas []string `json:"schemas,omitempty"`
+
+	Name *GetUserName `json:"name,omitempty"`
+
+	UserName *string `json:"userName,omitempty"`
+
+	ID *string `json:"id" validate:"required"`
+
+	Status *string `json:"status" validate:"required"`
+}
+
+// UnmarshalGetUserAndProfileIdentitiesItemIDPUserInfo unmarshals an instance of GetUserAndProfileIdentitiesItemIDPUserInfo from the specified map of raw messages.
+func UnmarshalGetUserAndProfileIdentitiesItemIDPUserInfo(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(GetUserAndProfileIdentitiesItemIDPUserInfo)
+	err = core.UnmarshalPrimitive(m, "displayName", &obj.DisplayName)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "active", &obj.Active)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "lockedUntil", &obj.LockedUntil)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalModel(m, "emails", &obj.Emails, UnmarshalGetUserEmailsItem)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalModel(m, "meta", &obj.Meta, UnmarshalGetUserMeta)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "schemas", &obj.Schemas)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalModel(m, "name", &obj.Name, UnmarshalGetUserName)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "userName", &obj.UserName)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "id", &obj.ID)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "status", &obj.Status)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
+// GetUserEmailsItem : GetUserEmailsItem struct
+type GetUserEmailsItem struct {
+	Value *string `json:"value" validate:"required"`
+
+	Primary *bool `json:"primary,omitempty"`
+}
+
+// UnmarshalGetUserEmailsItem unmarshals an instance of GetUserEmailsItem from the specified map of raw messages.
+func UnmarshalGetUserEmailsItem(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(GetUserEmailsItem)
+	err = core.UnmarshalPrimitive(m, "value", &obj.Value)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "primary", &obj.Primary)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
+// GetUserMeta : GetUserMeta struct
+type GetUserMeta struct {
+	Created *strfmt.DateTime `json:"created,omitempty"`
+
+	LastModified *strfmt.DateTime `json:"lastModified,omitempty"`
+
+	ResourceType *string `json:"resourceType,omitempty"`
+}
+
+// UnmarshalGetUserMeta unmarshals an instance of GetUserMeta from the specified map of raw messages.
+func UnmarshalGetUserMeta(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(GetUserMeta)
+	err = core.UnmarshalPrimitive(m, "created", &obj.Created)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "lastModified", &obj.LastModified)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "resourceType", &obj.ResourceType)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
+// GetUserName : GetUserName struct
+type GetUserName struct {
+	GivenName *string `json:"givenName,omitempty"`
+
+	FamilyName *string `json:"familyName,omitempty"`
+
+	Formatted *string `json:"formatted,omitempty"`
+}
+
+// UnmarshalGetUserName unmarshals an instance of GetUserName from the specified map of raw messages.
+func UnmarshalGetUserName(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(GetUserName)
+	err = core.UnmarshalPrimitive(m, "givenName", &obj.GivenName)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "familyName", &obj.FamilyName)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "formatted", &obj.Formatted)
 	if err != nil {
 		return
 	}
@@ -11196,7 +11463,14 @@ type StartSignUpOptions struct {
 
 	Active *bool
 
+	LockedUntil *int64
+
+	DisplayName *string
+
 	UserName *string
+
+	// Accepted values "PENDING" or "CONFIRMED".
+	Status *string
 
 	// Preferred language for resource. Format as described at RFC5646.
 	Language *string
@@ -11245,9 +11519,27 @@ func (options *StartSignUpOptions) SetActive(active bool) *StartSignUpOptions {
 	return options
 }
 
+// SetLockedUntil : Allow user to set LockedUntil
+func (options *StartSignUpOptions) SetLockedUntil(lockedUntil int64) *StartSignUpOptions {
+	options.LockedUntil = core.Int64Ptr(lockedUntil)
+	return options
+}
+
+// SetDisplayName : Allow user to set DisplayName
+func (options *StartSignUpOptions) SetDisplayName(displayName string) *StartSignUpOptions {
+	options.DisplayName = core.StringPtr(displayName)
+	return options
+}
+
 // SetUserName : Allow user to set UserName
 func (options *StartSignUpOptions) SetUserName(userName string) *StartSignUpOptions {
 	options.UserName = core.StringPtr(userName)
+	return options
+}
+
+// SetStatus : Allow user to set Status
+func (options *StartSignUpOptions) SetStatus(status string) *StartSignUpOptions {
+	options.Status = core.StringPtr(status)
 	return options
 }
 
@@ -11383,11 +11675,17 @@ type UpdateCloudDirectoryUserOptions struct {
 
 	Emails []CreateNewUserEmailsItem `validate:"required"`
 
-	Active *bool
+	Status *string
+
+	DisplayName *string
 
 	UserName *string
 
 	Password *string
+
+	Active *bool
+
+	LockedUntil *int64
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
@@ -11420,9 +11718,15 @@ func (options *UpdateCloudDirectoryUserOptions) SetEmails(emails []CreateNewUser
 	return options
 }
 
-// SetActive : Allow user to set Active
-func (options *UpdateCloudDirectoryUserOptions) SetActive(active bool) *UpdateCloudDirectoryUserOptions {
-	options.Active = core.BoolPtr(active)
+// SetStatus : Allow user to set Status
+func (options *UpdateCloudDirectoryUserOptions) SetStatus(status string) *UpdateCloudDirectoryUserOptions {
+	options.Status = core.StringPtr(status)
+	return options
+}
+
+// SetDisplayName : Allow user to set DisplayName
+func (options *UpdateCloudDirectoryUserOptions) SetDisplayName(displayName string) *UpdateCloudDirectoryUserOptions {
+	options.DisplayName = core.StringPtr(displayName)
 	return options
 }
 
@@ -11435,6 +11739,18 @@ func (options *UpdateCloudDirectoryUserOptions) SetUserName(userName string) *Up
 // SetPassword : Allow user to set Password
 func (options *UpdateCloudDirectoryUserOptions) SetPassword(password string) *UpdateCloudDirectoryUserOptions {
 	options.Password = core.StringPtr(password)
+	return options
+}
+
+// SetActive : Allow user to set Active
+func (options *UpdateCloudDirectoryUserOptions) SetActive(active bool) *UpdateCloudDirectoryUserOptions {
+	options.Active = core.BoolPtr(active)
+	return options
+}
+
+// SetLockedUntil : Allow user to set LockedUntil
+func (options *UpdateCloudDirectoryUserOptions) SetLockedUntil(lockedUntil int64) *UpdateCloudDirectoryUserOptions {
+	options.LockedUntil = core.Int64Ptr(lockedUntil)
 	return options
 }
 
@@ -13290,6 +13606,76 @@ func UnmarshalGetTemplate(m map[string]json.RawMessage, result interface{}) (err
 		return
 	}
 	err = core.UnmarshalPrimitive(m, "plain_text_body", &obj.PlainTextBody)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
+// GetUser : GetUser struct
+type GetUser struct {
+	DisplayName *string `json:"displayName,omitempty"`
+
+	Active *bool `json:"active" validate:"required"`
+
+	LockedUntil *int64 `json:"lockedUntil,omitempty"`
+
+	Emails []GetUserEmailsItem `json:"emails" validate:"required"`
+
+	Meta *GetUserMeta `json:"meta" validate:"required"`
+
+	Schemas []string `json:"schemas,omitempty"`
+
+	Name *GetUserName `json:"name,omitempty"`
+
+	UserName *string `json:"userName,omitempty"`
+
+	ID *string `json:"id" validate:"required"`
+
+	Status *string `json:"status" validate:"required"`
+}
+
+// UnmarshalGetUser unmarshals an instance of GetUser from the specified map of raw messages.
+func UnmarshalGetUser(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(GetUser)
+	err = core.UnmarshalPrimitive(m, "displayName", &obj.DisplayName)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "active", &obj.Active)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "lockedUntil", &obj.LockedUntil)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalModel(m, "emails", &obj.Emails, UnmarshalGetUserEmailsItem)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalModel(m, "meta", &obj.Meta, UnmarshalGetUserMeta)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "schemas", &obj.Schemas)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalModel(m, "name", &obj.Name, UnmarshalGetUserName)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "userName", &obj.UserName)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "id", &obj.ID)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "status", &obj.Status)
 	if err != nil {
 		return
 	}

--- a/appidmanagementv4/app_id_management_v4_test.go
+++ b/appidmanagementv4/app_id_management_v4_test.go
@@ -2366,8 +2366,150 @@ var _ = Describe(`AppIDManagementV4`, func() {
 			})
 		})
 	})
+	Describe(`CreateCloudDirectoryUser(createCloudDirectoryUserOptions *CreateCloudDirectoryUserOptions) - Operation response error`, func() {
+		createCloudDirectoryUserPath := "/management/v4/testString/cloud_directory/Users"
+		Context(`Using mock server endpoint with invalid JSON response`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(createCloudDirectoryUserPath))
+					Expect(req.Method).To(Equal("POST"))
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(201)
+					fmt.Fprintf(res, `} this is not valid json {`)
+				}))
+			})
+			It(`Invoke CreateCloudDirectoryUser with error: Operation response processing error`, func() {
+				appIDManagementService, serviceErr := appidmanagementv4.NewAppIDManagementV4(&appidmanagementv4.AppIDManagementV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(appIDManagementService).ToNot(BeNil())
+
+				// Construct an instance of the CreateNewUserEmailsItem model
+				createNewUserEmailsItemModel := new(appidmanagementv4.CreateNewUserEmailsItem)
+				createNewUserEmailsItemModel.Value = core.StringPtr("user@mail.com")
+				createNewUserEmailsItemModel.Primary = core.BoolPtr(true)
+
+				// Construct an instance of the CreateCloudDirectoryUserOptions model
+				createCloudDirectoryUserOptionsModel := new(appidmanagementv4.CreateCloudDirectoryUserOptions)
+				createCloudDirectoryUserOptionsModel.TenantID = core.StringPtr("testString")
+				createCloudDirectoryUserOptionsModel.Emails = []appidmanagementv4.CreateNewUserEmailsItem{*createNewUserEmailsItemModel}
+				createCloudDirectoryUserOptionsModel.Password = core.StringPtr("userPassword")
+				createCloudDirectoryUserOptionsModel.Active = core.BoolPtr(true)
+				createCloudDirectoryUserOptionsModel.LockedUntil = core.Int64Ptr(int64(1834879417592))
+				createCloudDirectoryUserOptionsModel.DisplayName = core.StringPtr("testString")
+				createCloudDirectoryUserOptionsModel.UserName = core.StringPtr("myUserName")
+				createCloudDirectoryUserOptionsModel.Status = core.StringPtr("PENDING")
+				createCloudDirectoryUserOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Expect response parsing to fail since we are receiving a text/plain response
+				result, response, operationErr := appIDManagementService.CreateCloudDirectoryUser(createCloudDirectoryUserOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+
+				// Enable retries and test again
+				appIDManagementService.EnableRetries(0, 0)
+				result, response, operationErr = appIDManagementService.CreateCloudDirectoryUser(createCloudDirectoryUserOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
 	Describe(`CreateCloudDirectoryUser(createCloudDirectoryUserOptions *CreateCloudDirectoryUserOptions)`, func() {
 		createCloudDirectoryUserPath := "/management/v4/testString/cloud_directory/Users"
+		Context(`Using mock server endpoint with timeout`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(createCloudDirectoryUserPath))
+					Expect(req.Method).To(Equal("POST"))
+
+					// For gzip-disabled operation, verify Content-Encoding is not set.
+					Expect(req.Header.Get("Content-Encoding")).To(BeEmpty())
+
+					// If there is a body, then make sure we can read it
+					bodyBuf := new(bytes.Buffer)
+					if req.Header.Get("Content-Encoding") == "gzip" {
+						body, err := core.NewGzipDecompressionReader(req.Body)
+						Expect(err).To(BeNil())
+						_, err = bodyBuf.ReadFrom(body)
+						Expect(err).To(BeNil())
+					} else {
+						_, err := bodyBuf.ReadFrom(req.Body)
+						Expect(err).To(BeNil())
+					}
+					fmt.Fprintf(GinkgoWriter, "  Request body: %s", bodyBuf.String())
+
+					// Sleep a short time to support a timeout test
+					time.Sleep(100 * time.Millisecond)
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(201)
+					fmt.Fprintf(res, "%s", `{"displayName": "DisplayName", "active": true, "lockedUntil": 11, "emails": [{"value": "Value", "primary": false}], "meta": {"created": "2019-01-01T12:00:00.000Z", "lastModified": "2019-01-01T12:00:00.000Z", "resourceType": "ResourceType"}, "schemas": ["Schemas"], "name": {"givenName": "GivenName", "familyName": "FamilyName", "formatted": "Formatted"}, "userName": "UserName", "id": "ID", "status": "Status"}`)
+				}))
+			})
+			It(`Invoke CreateCloudDirectoryUser successfully with retries`, func() {
+				appIDManagementService, serviceErr := appidmanagementv4.NewAppIDManagementV4(&appidmanagementv4.AppIDManagementV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(appIDManagementService).ToNot(BeNil())
+				appIDManagementService.EnableRetries(0, 0)
+
+				// Construct an instance of the CreateNewUserEmailsItem model
+				createNewUserEmailsItemModel := new(appidmanagementv4.CreateNewUserEmailsItem)
+				createNewUserEmailsItemModel.Value = core.StringPtr("user@mail.com")
+				createNewUserEmailsItemModel.Primary = core.BoolPtr(true)
+
+				// Construct an instance of the CreateCloudDirectoryUserOptions model
+				createCloudDirectoryUserOptionsModel := new(appidmanagementv4.CreateCloudDirectoryUserOptions)
+				createCloudDirectoryUserOptionsModel.TenantID = core.StringPtr("testString")
+				createCloudDirectoryUserOptionsModel.Emails = []appidmanagementv4.CreateNewUserEmailsItem{*createNewUserEmailsItemModel}
+				createCloudDirectoryUserOptionsModel.Password = core.StringPtr("userPassword")
+				createCloudDirectoryUserOptionsModel.Active = core.BoolPtr(true)
+				createCloudDirectoryUserOptionsModel.LockedUntil = core.Int64Ptr(int64(1834879417592))
+				createCloudDirectoryUserOptionsModel.DisplayName = core.StringPtr("testString")
+				createCloudDirectoryUserOptionsModel.UserName = core.StringPtr("myUserName")
+				createCloudDirectoryUserOptionsModel.Status = core.StringPtr("PENDING")
+				createCloudDirectoryUserOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with a Context to test a timeout error
+				ctx, cancelFunc := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc()
+				_, _, operationErr := appIDManagementService.CreateCloudDirectoryUserWithContext(ctx, createCloudDirectoryUserOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+
+				// Disable retries and test again
+				appIDManagementService.DisableRetries()
+				result, response, operationErr := appIDManagementService.CreateCloudDirectoryUser(createCloudDirectoryUserOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+				// Re-test the timeout error with retries disabled
+				ctx, cancelFunc2 := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc2()
+				_, _, operationErr = appIDManagementService.CreateCloudDirectoryUserWithContext(ctx, createCloudDirectoryUserOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
 		Context(`Using mock server endpoint`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -2393,7 +2535,10 @@ var _ = Describe(`AppIDManagementV4`, func() {
 					}
 					fmt.Fprintf(GinkgoWriter, "  Request body: %s", bodyBuf.String())
 
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
+					fmt.Fprintf(res, "%s", `{"displayName": "DisplayName", "active": true, "lockedUntil": 11, "emails": [{"value": "Value", "primary": false}], "meta": {"created": "2019-01-01T12:00:00.000Z", "lastModified": "2019-01-01T12:00:00.000Z", "resourceType": "ResourceType"}, "schemas": ["Schemas"], "name": {"givenName": "GivenName", "familyName": "FamilyName", "formatted": "Formatted"}, "userName": "UserName", "id": "ID", "status": "Status"}`)
 				}))
 			})
 			It(`Invoke CreateCloudDirectoryUser successfully`, func() {
@@ -2405,9 +2550,10 @@ var _ = Describe(`AppIDManagementV4`, func() {
 				Expect(appIDManagementService).ToNot(BeNil())
 
 				// Invoke operation with nil options model (negative test)
-				response, operationErr := appIDManagementService.CreateCloudDirectoryUser(nil)
+				result, response, operationErr := appIDManagementService.CreateCloudDirectoryUser(nil)
 				Expect(operationErr).NotTo(BeNil())
 				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
 
 				// Construct an instance of the CreateNewUserEmailsItem model
 				createNewUserEmailsItemModel := new(appidmanagementv4.CreateNewUserEmailsItem)
@@ -2420,13 +2566,18 @@ var _ = Describe(`AppIDManagementV4`, func() {
 				createCloudDirectoryUserOptionsModel.Emails = []appidmanagementv4.CreateNewUserEmailsItem{*createNewUserEmailsItemModel}
 				createCloudDirectoryUserOptionsModel.Password = core.StringPtr("userPassword")
 				createCloudDirectoryUserOptionsModel.Active = core.BoolPtr(true)
+				createCloudDirectoryUserOptionsModel.LockedUntil = core.Int64Ptr(int64(1834879417592))
+				createCloudDirectoryUserOptionsModel.DisplayName = core.StringPtr("testString")
 				createCloudDirectoryUserOptionsModel.UserName = core.StringPtr("myUserName")
+				createCloudDirectoryUserOptionsModel.Status = core.StringPtr("PENDING")
 				createCloudDirectoryUserOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation with valid options model (positive test)
-				response, operationErr = appIDManagementService.CreateCloudDirectoryUser(createCloudDirectoryUserOptionsModel)
+				result, response, operationErr = appIDManagementService.CreateCloudDirectoryUser(createCloudDirectoryUserOptionsModel)
 				Expect(operationErr).To(BeNil())
 				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
 			})
 			It(`Invoke CreateCloudDirectoryUser with error: Operation validation and request error`, func() {
 				appIDManagementService, serviceErr := appidmanagementv4.NewAppIDManagementV4(&appidmanagementv4.AppIDManagementV4Options{
@@ -2447,21 +2598,118 @@ var _ = Describe(`AppIDManagementV4`, func() {
 				createCloudDirectoryUserOptionsModel.Emails = []appidmanagementv4.CreateNewUserEmailsItem{*createNewUserEmailsItemModel}
 				createCloudDirectoryUserOptionsModel.Password = core.StringPtr("userPassword")
 				createCloudDirectoryUserOptionsModel.Active = core.BoolPtr(true)
+				createCloudDirectoryUserOptionsModel.LockedUntil = core.Int64Ptr(int64(1834879417592))
+				createCloudDirectoryUserOptionsModel.DisplayName = core.StringPtr("testString")
 				createCloudDirectoryUserOptionsModel.UserName = core.StringPtr("myUserName")
+				createCloudDirectoryUserOptionsModel.Status = core.StringPtr("PENDING")
 				createCloudDirectoryUserOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Invoke operation with empty URL (negative test)
 				err := appIDManagementService.SetServiceURL("")
 				Expect(err).To(BeNil())
-				response, operationErr := appIDManagementService.CreateCloudDirectoryUser(createCloudDirectoryUserOptionsModel)
+				result, response, operationErr := appIDManagementService.CreateCloudDirectoryUser(createCloudDirectoryUserOptionsModel)
 				Expect(operationErr).ToNot(BeNil())
 				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
 				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
 				// Construct a second instance of the CreateCloudDirectoryUserOptions model with no property values
 				createCloudDirectoryUserOptionsModelNew := new(appidmanagementv4.CreateCloudDirectoryUserOptions)
 				// Invoke operation with invalid model (negative test)
-				response, operationErr = appIDManagementService.CreateCloudDirectoryUser(createCloudDirectoryUserOptionsModelNew)
+				result, response, operationErr = appIDManagementService.CreateCloudDirectoryUser(createCloudDirectoryUserOptionsModelNew)
 				Expect(operationErr).ToNot(BeNil())
 				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint with missing response body`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Set success status code with no respoonse body
+					res.WriteHeader(201)
+				}))
+			})
+			It(`Invoke CreateCloudDirectoryUser successfully`, func() {
+				appIDManagementService, serviceErr := appidmanagementv4.NewAppIDManagementV4(&appidmanagementv4.AppIDManagementV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(appIDManagementService).ToNot(BeNil())
+
+				// Construct an instance of the CreateNewUserEmailsItem model
+				createNewUserEmailsItemModel := new(appidmanagementv4.CreateNewUserEmailsItem)
+				createNewUserEmailsItemModel.Value = core.StringPtr("user@mail.com")
+				createNewUserEmailsItemModel.Primary = core.BoolPtr(true)
+
+				// Construct an instance of the CreateCloudDirectoryUserOptions model
+				createCloudDirectoryUserOptionsModel := new(appidmanagementv4.CreateCloudDirectoryUserOptions)
+				createCloudDirectoryUserOptionsModel.TenantID = core.StringPtr("testString")
+				createCloudDirectoryUserOptionsModel.Emails = []appidmanagementv4.CreateNewUserEmailsItem{*createNewUserEmailsItemModel}
+				createCloudDirectoryUserOptionsModel.Password = core.StringPtr("userPassword")
+				createCloudDirectoryUserOptionsModel.Active = core.BoolPtr(true)
+				createCloudDirectoryUserOptionsModel.LockedUntil = core.Int64Ptr(int64(1834879417592))
+				createCloudDirectoryUserOptionsModel.DisplayName = core.StringPtr("testString")
+				createCloudDirectoryUserOptionsModel.UserName = core.StringPtr("myUserName")
+				createCloudDirectoryUserOptionsModel.Status = core.StringPtr("PENDING")
+				createCloudDirectoryUserOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation
+				result, response, operationErr := appIDManagementService.CreateCloudDirectoryUser(createCloudDirectoryUserOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+
+				// Verify a nil result
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`GetCloudDirectoryUser(getCloudDirectoryUserOptions *GetCloudDirectoryUserOptions) - Operation response error`, func() {
+		getCloudDirectoryUserPath := "/management/v4/testString/cloud_directory/Users/testString"
+		Context(`Using mock server endpoint with invalid JSON response`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(getCloudDirectoryUserPath))
+					Expect(req.Method).To(Equal("GET"))
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, `} this is not valid json {`)
+				}))
+			})
+			It(`Invoke GetCloudDirectoryUser with error: Operation response processing error`, func() {
+				appIDManagementService, serviceErr := appidmanagementv4.NewAppIDManagementV4(&appidmanagementv4.AppIDManagementV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(appIDManagementService).ToNot(BeNil())
+
+				// Construct an instance of the GetCloudDirectoryUserOptions model
+				getCloudDirectoryUserOptionsModel := new(appidmanagementv4.GetCloudDirectoryUserOptions)
+				getCloudDirectoryUserOptionsModel.TenantID = core.StringPtr("testString")
+				getCloudDirectoryUserOptionsModel.UserID = core.StringPtr("testString")
+				getCloudDirectoryUserOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Expect response parsing to fail since we are receiving a text/plain response
+				result, response, operationErr := appIDManagementService.GetCloudDirectoryUser(getCloudDirectoryUserOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+
+				// Enable retries and test again
+				appIDManagementService.EnableRetries(0, 0)
+				result, response, operationErr = appIDManagementService.GetCloudDirectoryUser(getCloudDirectoryUserOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
 			})
 			AfterEach(func() {
 				testServer.Close()
@@ -2470,6 +2718,64 @@ var _ = Describe(`AppIDManagementV4`, func() {
 	})
 	Describe(`GetCloudDirectoryUser(getCloudDirectoryUserOptions *GetCloudDirectoryUserOptions)`, func() {
 		getCloudDirectoryUserPath := "/management/v4/testString/cloud_directory/Users/testString"
+		Context(`Using mock server endpoint with timeout`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(getCloudDirectoryUserPath))
+					Expect(req.Method).To(Equal("GET"))
+
+					// Sleep a short time to support a timeout test
+					time.Sleep(100 * time.Millisecond)
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"displayName": "DisplayName", "active": true, "lockedUntil": 11, "emails": [{"value": "Value", "primary": false}], "meta": {"created": "2019-01-01T12:00:00.000Z", "lastModified": "2019-01-01T12:00:00.000Z", "resourceType": "ResourceType"}, "schemas": ["Schemas"], "name": {"givenName": "GivenName", "familyName": "FamilyName", "formatted": "Formatted"}, "userName": "UserName", "id": "ID", "status": "Status"}`)
+				}))
+			})
+			It(`Invoke GetCloudDirectoryUser successfully with retries`, func() {
+				appIDManagementService, serviceErr := appidmanagementv4.NewAppIDManagementV4(&appidmanagementv4.AppIDManagementV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(appIDManagementService).ToNot(BeNil())
+				appIDManagementService.EnableRetries(0, 0)
+
+				// Construct an instance of the GetCloudDirectoryUserOptions model
+				getCloudDirectoryUserOptionsModel := new(appidmanagementv4.GetCloudDirectoryUserOptions)
+				getCloudDirectoryUserOptionsModel.TenantID = core.StringPtr("testString")
+				getCloudDirectoryUserOptionsModel.UserID = core.StringPtr("testString")
+				getCloudDirectoryUserOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with a Context to test a timeout error
+				ctx, cancelFunc := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc()
+				_, _, operationErr := appIDManagementService.GetCloudDirectoryUserWithContext(ctx, getCloudDirectoryUserOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+
+				// Disable retries and test again
+				appIDManagementService.DisableRetries()
+				result, response, operationErr := appIDManagementService.GetCloudDirectoryUser(getCloudDirectoryUserOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+				// Re-test the timeout error with retries disabled
+				ctx, cancelFunc2 := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc2()
+				_, _, operationErr = appIDManagementService.GetCloudDirectoryUserWithContext(ctx, getCloudDirectoryUserOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
 		Context(`Using mock server endpoint`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -2479,7 +2785,10 @@ var _ = Describe(`AppIDManagementV4`, func() {
 					Expect(req.URL.EscapedPath()).To(Equal(getCloudDirectoryUserPath))
 					Expect(req.Method).To(Equal("GET"))
 
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"displayName": "DisplayName", "active": true, "lockedUntil": 11, "emails": [{"value": "Value", "primary": false}], "meta": {"created": "2019-01-01T12:00:00.000Z", "lastModified": "2019-01-01T12:00:00.000Z", "resourceType": "ResourceType"}, "schemas": ["Schemas"], "name": {"givenName": "GivenName", "familyName": "FamilyName", "formatted": "Formatted"}, "userName": "UserName", "id": "ID", "status": "Status"}`)
 				}))
 			})
 			It(`Invoke GetCloudDirectoryUser successfully`, func() {
@@ -2491,9 +2800,10 @@ var _ = Describe(`AppIDManagementV4`, func() {
 				Expect(appIDManagementService).ToNot(BeNil())
 
 				// Invoke operation with nil options model (negative test)
-				response, operationErr := appIDManagementService.GetCloudDirectoryUser(nil)
+				result, response, operationErr := appIDManagementService.GetCloudDirectoryUser(nil)
 				Expect(operationErr).NotTo(BeNil())
 				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
 
 				// Construct an instance of the GetCloudDirectoryUserOptions model
 				getCloudDirectoryUserOptionsModel := new(appidmanagementv4.GetCloudDirectoryUserOptions)
@@ -2502,9 +2812,11 @@ var _ = Describe(`AppIDManagementV4`, func() {
 				getCloudDirectoryUserOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation with valid options model (positive test)
-				response, operationErr = appIDManagementService.GetCloudDirectoryUser(getCloudDirectoryUserOptionsModel)
+				result, response, operationErr = appIDManagementService.GetCloudDirectoryUser(getCloudDirectoryUserOptionsModel)
 				Expect(operationErr).To(BeNil())
 				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
 			})
 			It(`Invoke GetCloudDirectoryUser with error: Operation validation and request error`, func() {
 				appIDManagementService, serviceErr := appidmanagementv4.NewAppIDManagementV4(&appidmanagementv4.AppIDManagementV4Options{
@@ -2522,16 +2834,111 @@ var _ = Describe(`AppIDManagementV4`, func() {
 				// Invoke operation with empty URL (negative test)
 				err := appIDManagementService.SetServiceURL("")
 				Expect(err).To(BeNil())
-				response, operationErr := appIDManagementService.GetCloudDirectoryUser(getCloudDirectoryUserOptionsModel)
+				result, response, operationErr := appIDManagementService.GetCloudDirectoryUser(getCloudDirectoryUserOptionsModel)
 				Expect(operationErr).ToNot(BeNil())
 				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
 				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
 				// Construct a second instance of the GetCloudDirectoryUserOptions model with no property values
 				getCloudDirectoryUserOptionsModelNew := new(appidmanagementv4.GetCloudDirectoryUserOptions)
 				// Invoke operation with invalid model (negative test)
-				response, operationErr = appIDManagementService.GetCloudDirectoryUser(getCloudDirectoryUserOptionsModelNew)
+				result, response, operationErr = appIDManagementService.GetCloudDirectoryUser(getCloudDirectoryUserOptionsModelNew)
 				Expect(operationErr).ToNot(BeNil())
 				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint with missing response body`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Set success status code with no respoonse body
+					res.WriteHeader(200)
+				}))
+			})
+			It(`Invoke GetCloudDirectoryUser successfully`, func() {
+				appIDManagementService, serviceErr := appidmanagementv4.NewAppIDManagementV4(&appidmanagementv4.AppIDManagementV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(appIDManagementService).ToNot(BeNil())
+
+				// Construct an instance of the GetCloudDirectoryUserOptions model
+				getCloudDirectoryUserOptionsModel := new(appidmanagementv4.GetCloudDirectoryUserOptions)
+				getCloudDirectoryUserOptionsModel.TenantID = core.StringPtr("testString")
+				getCloudDirectoryUserOptionsModel.UserID = core.StringPtr("testString")
+				getCloudDirectoryUserOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation
+				result, response, operationErr := appIDManagementService.GetCloudDirectoryUser(getCloudDirectoryUserOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+
+				// Verify a nil result
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`UpdateCloudDirectoryUser(updateCloudDirectoryUserOptions *UpdateCloudDirectoryUserOptions) - Operation response error`, func() {
+		updateCloudDirectoryUserPath := "/management/v4/testString/cloud_directory/Users/testString"
+		Context(`Using mock server endpoint with invalid JSON response`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(updateCloudDirectoryUserPath))
+					Expect(req.Method).To(Equal("PUT"))
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, `} this is not valid json {`)
+				}))
+			})
+			It(`Invoke UpdateCloudDirectoryUser with error: Operation response processing error`, func() {
+				appIDManagementService, serviceErr := appidmanagementv4.NewAppIDManagementV4(&appidmanagementv4.AppIDManagementV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(appIDManagementService).ToNot(BeNil())
+
+				// Construct an instance of the CreateNewUserEmailsItem model
+				createNewUserEmailsItemModel := new(appidmanagementv4.CreateNewUserEmailsItem)
+				createNewUserEmailsItemModel.Value = core.StringPtr("user@mail.com")
+				createNewUserEmailsItemModel.Primary = core.BoolPtr(true)
+
+				// Construct an instance of the UpdateCloudDirectoryUserOptions model
+				updateCloudDirectoryUserOptionsModel := new(appidmanagementv4.UpdateCloudDirectoryUserOptions)
+				updateCloudDirectoryUserOptionsModel.TenantID = core.StringPtr("testString")
+				updateCloudDirectoryUserOptionsModel.UserID = core.StringPtr("testString")
+				updateCloudDirectoryUserOptionsModel.Emails = []appidmanagementv4.CreateNewUserEmailsItem{*createNewUserEmailsItemModel}
+				updateCloudDirectoryUserOptionsModel.Status = core.StringPtr("testString")
+				updateCloudDirectoryUserOptionsModel.DisplayName = core.StringPtr("testString")
+				updateCloudDirectoryUserOptionsModel.UserName = core.StringPtr("myUserName")
+				updateCloudDirectoryUserOptionsModel.Password = core.StringPtr("userPassword")
+				updateCloudDirectoryUserOptionsModel.Active = core.BoolPtr(false)
+				updateCloudDirectoryUserOptionsModel.LockedUntil = core.Int64Ptr(int64(1834879417592))
+				updateCloudDirectoryUserOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Expect response parsing to fail since we are receiving a text/plain response
+				result, response, operationErr := appIDManagementService.UpdateCloudDirectoryUser(updateCloudDirectoryUserOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+
+				// Enable retries and test again
+				appIDManagementService.EnableRetries(0, 0)
+				result, response, operationErr = appIDManagementService.UpdateCloudDirectoryUser(updateCloudDirectoryUserOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
 			})
 			AfterEach(func() {
 				testServer.Close()
@@ -2540,6 +2947,92 @@ var _ = Describe(`AppIDManagementV4`, func() {
 	})
 	Describe(`UpdateCloudDirectoryUser(updateCloudDirectoryUserOptions *UpdateCloudDirectoryUserOptions)`, func() {
 		updateCloudDirectoryUserPath := "/management/v4/testString/cloud_directory/Users/testString"
+		Context(`Using mock server endpoint with timeout`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(updateCloudDirectoryUserPath))
+					Expect(req.Method).To(Equal("PUT"))
+
+					// For gzip-disabled operation, verify Content-Encoding is not set.
+					Expect(req.Header.Get("Content-Encoding")).To(BeEmpty())
+
+					// If there is a body, then make sure we can read it
+					bodyBuf := new(bytes.Buffer)
+					if req.Header.Get("Content-Encoding") == "gzip" {
+						body, err := core.NewGzipDecompressionReader(req.Body)
+						Expect(err).To(BeNil())
+						_, err = bodyBuf.ReadFrom(body)
+						Expect(err).To(BeNil())
+					} else {
+						_, err := bodyBuf.ReadFrom(req.Body)
+						Expect(err).To(BeNil())
+					}
+					fmt.Fprintf(GinkgoWriter, "  Request body: %s", bodyBuf.String())
+
+					// Sleep a short time to support a timeout test
+					time.Sleep(100 * time.Millisecond)
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"displayName": "DisplayName", "active": true, "lockedUntil": 11, "emails": [{"value": "Value", "primary": false}], "meta": {"created": "2019-01-01T12:00:00.000Z", "lastModified": "2019-01-01T12:00:00.000Z", "resourceType": "ResourceType"}, "schemas": ["Schemas"], "name": {"givenName": "GivenName", "familyName": "FamilyName", "formatted": "Formatted"}, "userName": "UserName", "id": "ID", "status": "Status"}`)
+				}))
+			})
+			It(`Invoke UpdateCloudDirectoryUser successfully with retries`, func() {
+				appIDManagementService, serviceErr := appidmanagementv4.NewAppIDManagementV4(&appidmanagementv4.AppIDManagementV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(appIDManagementService).ToNot(BeNil())
+				appIDManagementService.EnableRetries(0, 0)
+
+				// Construct an instance of the CreateNewUserEmailsItem model
+				createNewUserEmailsItemModel := new(appidmanagementv4.CreateNewUserEmailsItem)
+				createNewUserEmailsItemModel.Value = core.StringPtr("user@mail.com")
+				createNewUserEmailsItemModel.Primary = core.BoolPtr(true)
+
+				// Construct an instance of the UpdateCloudDirectoryUserOptions model
+				updateCloudDirectoryUserOptionsModel := new(appidmanagementv4.UpdateCloudDirectoryUserOptions)
+				updateCloudDirectoryUserOptionsModel.TenantID = core.StringPtr("testString")
+				updateCloudDirectoryUserOptionsModel.UserID = core.StringPtr("testString")
+				updateCloudDirectoryUserOptionsModel.Emails = []appidmanagementv4.CreateNewUserEmailsItem{*createNewUserEmailsItemModel}
+				updateCloudDirectoryUserOptionsModel.Status = core.StringPtr("testString")
+				updateCloudDirectoryUserOptionsModel.DisplayName = core.StringPtr("testString")
+				updateCloudDirectoryUserOptionsModel.UserName = core.StringPtr("myUserName")
+				updateCloudDirectoryUserOptionsModel.Password = core.StringPtr("userPassword")
+				updateCloudDirectoryUserOptionsModel.Active = core.BoolPtr(false)
+				updateCloudDirectoryUserOptionsModel.LockedUntil = core.Int64Ptr(int64(1834879417592))
+				updateCloudDirectoryUserOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with a Context to test a timeout error
+				ctx, cancelFunc := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc()
+				_, _, operationErr := appIDManagementService.UpdateCloudDirectoryUserWithContext(ctx, updateCloudDirectoryUserOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+
+				// Disable retries and test again
+				appIDManagementService.DisableRetries()
+				result, response, operationErr := appIDManagementService.UpdateCloudDirectoryUser(updateCloudDirectoryUserOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+				// Re-test the timeout error with retries disabled
+				ctx, cancelFunc2 := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc2()
+				_, _, operationErr = appIDManagementService.UpdateCloudDirectoryUserWithContext(ctx, updateCloudDirectoryUserOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
 		Context(`Using mock server endpoint`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -2565,7 +3058,10 @@ var _ = Describe(`AppIDManagementV4`, func() {
 					}
 					fmt.Fprintf(GinkgoWriter, "  Request body: %s", bodyBuf.String())
 
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"displayName": "DisplayName", "active": true, "lockedUntil": 11, "emails": [{"value": "Value", "primary": false}], "meta": {"created": "2019-01-01T12:00:00.000Z", "lastModified": "2019-01-01T12:00:00.000Z", "resourceType": "ResourceType"}, "schemas": ["Schemas"], "name": {"givenName": "GivenName", "familyName": "FamilyName", "formatted": "Formatted"}, "userName": "UserName", "id": "ID", "status": "Status"}`)
 				}))
 			})
 			It(`Invoke UpdateCloudDirectoryUser successfully`, func() {
@@ -2577,9 +3073,10 @@ var _ = Describe(`AppIDManagementV4`, func() {
 				Expect(appIDManagementService).ToNot(BeNil())
 
 				// Invoke operation with nil options model (negative test)
-				response, operationErr := appIDManagementService.UpdateCloudDirectoryUser(nil)
+				result, response, operationErr := appIDManagementService.UpdateCloudDirectoryUser(nil)
 				Expect(operationErr).NotTo(BeNil())
 				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
 
 				// Construct an instance of the CreateNewUserEmailsItem model
 				createNewUserEmailsItemModel := new(appidmanagementv4.CreateNewUserEmailsItem)
@@ -2591,15 +3088,20 @@ var _ = Describe(`AppIDManagementV4`, func() {
 				updateCloudDirectoryUserOptionsModel.TenantID = core.StringPtr("testString")
 				updateCloudDirectoryUserOptionsModel.UserID = core.StringPtr("testString")
 				updateCloudDirectoryUserOptionsModel.Emails = []appidmanagementv4.CreateNewUserEmailsItem{*createNewUserEmailsItemModel}
-				updateCloudDirectoryUserOptionsModel.Active = core.BoolPtr(true)
+				updateCloudDirectoryUserOptionsModel.Status = core.StringPtr("testString")
+				updateCloudDirectoryUserOptionsModel.DisplayName = core.StringPtr("testString")
 				updateCloudDirectoryUserOptionsModel.UserName = core.StringPtr("myUserName")
 				updateCloudDirectoryUserOptionsModel.Password = core.StringPtr("userPassword")
+				updateCloudDirectoryUserOptionsModel.Active = core.BoolPtr(false)
+				updateCloudDirectoryUserOptionsModel.LockedUntil = core.Int64Ptr(int64(1834879417592))
 				updateCloudDirectoryUserOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation with valid options model (positive test)
-				response, operationErr = appIDManagementService.UpdateCloudDirectoryUser(updateCloudDirectoryUserOptionsModel)
+				result, response, operationErr = appIDManagementService.UpdateCloudDirectoryUser(updateCloudDirectoryUserOptionsModel)
 				Expect(operationErr).To(BeNil())
 				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
 			})
 			It(`Invoke UpdateCloudDirectoryUser with error: Operation validation and request error`, func() {
 				appIDManagementService, serviceErr := appidmanagementv4.NewAppIDManagementV4(&appidmanagementv4.AppIDManagementV4Options{
@@ -2619,23 +3121,75 @@ var _ = Describe(`AppIDManagementV4`, func() {
 				updateCloudDirectoryUserOptionsModel.TenantID = core.StringPtr("testString")
 				updateCloudDirectoryUserOptionsModel.UserID = core.StringPtr("testString")
 				updateCloudDirectoryUserOptionsModel.Emails = []appidmanagementv4.CreateNewUserEmailsItem{*createNewUserEmailsItemModel}
-				updateCloudDirectoryUserOptionsModel.Active = core.BoolPtr(true)
+				updateCloudDirectoryUserOptionsModel.Status = core.StringPtr("testString")
+				updateCloudDirectoryUserOptionsModel.DisplayName = core.StringPtr("testString")
 				updateCloudDirectoryUserOptionsModel.UserName = core.StringPtr("myUserName")
 				updateCloudDirectoryUserOptionsModel.Password = core.StringPtr("userPassword")
+				updateCloudDirectoryUserOptionsModel.Active = core.BoolPtr(false)
+				updateCloudDirectoryUserOptionsModel.LockedUntil = core.Int64Ptr(int64(1834879417592))
 				updateCloudDirectoryUserOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Invoke operation with empty URL (negative test)
 				err := appIDManagementService.SetServiceURL("")
 				Expect(err).To(BeNil())
-				response, operationErr := appIDManagementService.UpdateCloudDirectoryUser(updateCloudDirectoryUserOptionsModel)
+				result, response, operationErr := appIDManagementService.UpdateCloudDirectoryUser(updateCloudDirectoryUserOptionsModel)
 				Expect(operationErr).ToNot(BeNil())
 				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
 				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
 				// Construct a second instance of the UpdateCloudDirectoryUserOptions model with no property values
 				updateCloudDirectoryUserOptionsModelNew := new(appidmanagementv4.UpdateCloudDirectoryUserOptions)
 				// Invoke operation with invalid model (negative test)
-				response, operationErr = appIDManagementService.UpdateCloudDirectoryUser(updateCloudDirectoryUserOptionsModelNew)
+				result, response, operationErr = appIDManagementService.UpdateCloudDirectoryUser(updateCloudDirectoryUserOptionsModelNew)
 				Expect(operationErr).ToNot(BeNil())
 				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint with missing response body`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Set success status code with no respoonse body
+					res.WriteHeader(200)
+				}))
+			})
+			It(`Invoke UpdateCloudDirectoryUser successfully`, func() {
+				appIDManagementService, serviceErr := appidmanagementv4.NewAppIDManagementV4(&appidmanagementv4.AppIDManagementV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(appIDManagementService).ToNot(BeNil())
+
+				// Construct an instance of the CreateNewUserEmailsItem model
+				createNewUserEmailsItemModel := new(appidmanagementv4.CreateNewUserEmailsItem)
+				createNewUserEmailsItemModel.Value = core.StringPtr("user@mail.com")
+				createNewUserEmailsItemModel.Primary = core.BoolPtr(true)
+
+				// Construct an instance of the UpdateCloudDirectoryUserOptions model
+				updateCloudDirectoryUserOptionsModel := new(appidmanagementv4.UpdateCloudDirectoryUserOptions)
+				updateCloudDirectoryUserOptionsModel.TenantID = core.StringPtr("testString")
+				updateCloudDirectoryUserOptionsModel.UserID = core.StringPtr("testString")
+				updateCloudDirectoryUserOptionsModel.Emails = []appidmanagementv4.CreateNewUserEmailsItem{*createNewUserEmailsItemModel}
+				updateCloudDirectoryUserOptionsModel.Status = core.StringPtr("testString")
+				updateCloudDirectoryUserOptionsModel.DisplayName = core.StringPtr("testString")
+				updateCloudDirectoryUserOptionsModel.UserName = core.StringPtr("myUserName")
+				updateCloudDirectoryUserOptionsModel.Password = core.StringPtr("userPassword")
+				updateCloudDirectoryUserOptionsModel.Active = core.BoolPtr(false)
+				updateCloudDirectoryUserOptionsModel.LockedUntil = core.Int64Ptr(int64(1834879417592))
+				updateCloudDirectoryUserOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation
+				result, response, operationErr := appIDManagementService.UpdateCloudDirectoryUser(updateCloudDirectoryUserOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+
+				// Verify a nil result
+				Expect(result).To(BeNil())
 			})
 			AfterEach(func() {
 				testServer.Close()
@@ -3398,7 +3952,7 @@ var _ = Describe(`AppIDManagementV4`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"sub": "Sub", "identities": [{"provider": "Provider", "id": "ID", "idpUserInfo": {"anyKey": "anyValue"}}], "attributes": {"anyKey": "anyValue"}}`)
+					fmt.Fprintf(res, "%s", `{"sub": "Sub", "identities": [{"provider": "Provider", "id": "ID", "idpUserInfo": {"displayName": "DisplayName", "active": true, "lockedUntil": 11, "emails": [{"value": "Value", "primary": false}], "meta": {"created": "2019-01-01T12:00:00.000Z", "lastModified": "2019-01-01T12:00:00.000Z", "resourceType": "ResourceType"}, "schemas": ["Schemas"], "name": {"givenName": "GivenName", "familyName": "FamilyName", "formatted": "Formatted"}, "userName": "UserName", "id": "ID", "status": "Status"}}], "attributes": {"anyKey": "anyValue"}}`)
 				}))
 			})
 			It(`Invoke CloudDirectoryGetUserinfo successfully with retries`, func() {
@@ -3453,7 +4007,7 @@ var _ = Describe(`AppIDManagementV4`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"sub": "Sub", "identities": [{"provider": "Provider", "id": "ID", "idpUserInfo": {"anyKey": "anyValue"}}], "attributes": {"anyKey": "anyValue"}}`)
+					fmt.Fprintf(res, "%s", `{"sub": "Sub", "identities": [{"provider": "Provider", "id": "ID", "idpUserInfo": {"displayName": "DisplayName", "active": true, "lockedUntil": 11, "emails": [{"value": "Value", "primary": false}], "meta": {"created": "2019-01-01T12:00:00.000Z", "lastModified": "2019-01-01T12:00:00.000Z", "resourceType": "ResourceType"}, "schemas": ["Schemas"], "name": {"givenName": "GivenName", "familyName": "FamilyName", "formatted": "Formatted"}, "userName": "UserName", "id": "ID", "status": "Status"}}], "attributes": {"anyKey": "anyValue"}}`)
 				}))
 			})
 			It(`Invoke CloudDirectoryGetUserinfo successfully`, func() {
@@ -3552,8 +4106,158 @@ var _ = Describe(`AppIDManagementV4`, func() {
 			})
 		})
 	})
+	Describe(`StartSignUp(startSignUpOptions *StartSignUpOptions) - Operation response error`, func() {
+		startSignUpPath := "/management/v4/testString/cloud_directory/sign_up"
+		Context(`Using mock server endpoint with invalid JSON response`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(startSignUpPath))
+					Expect(req.Method).To(Equal("POST"))
+					// TODO: Add check for shouldCreateProfile query parameter
+					Expect(req.URL.Query()["language"]).To(Equal([]string{"testString"}))
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(201)
+					fmt.Fprintf(res, `} this is not valid json {`)
+				}))
+			})
+			It(`Invoke StartSignUp with error: Operation response processing error`, func() {
+				appIDManagementService, serviceErr := appidmanagementv4.NewAppIDManagementV4(&appidmanagementv4.AppIDManagementV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(appIDManagementService).ToNot(BeNil())
+
+				// Construct an instance of the CreateNewUserEmailsItem model
+				createNewUserEmailsItemModel := new(appidmanagementv4.CreateNewUserEmailsItem)
+				createNewUserEmailsItemModel.Value = core.StringPtr("user@mail.com")
+				createNewUserEmailsItemModel.Primary = core.BoolPtr(true)
+
+				// Construct an instance of the StartSignUpOptions model
+				startSignUpOptionsModel := new(appidmanagementv4.StartSignUpOptions)
+				startSignUpOptionsModel.TenantID = core.StringPtr("testString")
+				startSignUpOptionsModel.ShouldCreateProfile = core.BoolPtr(true)
+				startSignUpOptionsModel.Emails = []appidmanagementv4.CreateNewUserEmailsItem{*createNewUserEmailsItemModel}
+				startSignUpOptionsModel.Password = core.StringPtr("userPassword")
+				startSignUpOptionsModel.Active = core.BoolPtr(true)
+				startSignUpOptionsModel.LockedUntil = core.Int64Ptr(int64(1834879417592))
+				startSignUpOptionsModel.DisplayName = core.StringPtr("testString")
+				startSignUpOptionsModel.UserName = core.StringPtr("myUserName")
+				startSignUpOptionsModel.Status = core.StringPtr("PENDING")
+				startSignUpOptionsModel.Language = core.StringPtr("testString")
+				startSignUpOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Expect response parsing to fail since we are receiving a text/plain response
+				result, response, operationErr := appIDManagementService.StartSignUp(startSignUpOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+
+				// Enable retries and test again
+				appIDManagementService.EnableRetries(0, 0)
+				result, response, operationErr = appIDManagementService.StartSignUp(startSignUpOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
 	Describe(`StartSignUp(startSignUpOptions *StartSignUpOptions)`, func() {
 		startSignUpPath := "/management/v4/testString/cloud_directory/sign_up"
+		Context(`Using mock server endpoint with timeout`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(startSignUpPath))
+					Expect(req.Method).To(Equal("POST"))
+
+					// For gzip-disabled operation, verify Content-Encoding is not set.
+					Expect(req.Header.Get("Content-Encoding")).To(BeEmpty())
+
+					// If there is a body, then make sure we can read it
+					bodyBuf := new(bytes.Buffer)
+					if req.Header.Get("Content-Encoding") == "gzip" {
+						body, err := core.NewGzipDecompressionReader(req.Body)
+						Expect(err).To(BeNil())
+						_, err = bodyBuf.ReadFrom(body)
+						Expect(err).To(BeNil())
+					} else {
+						_, err := bodyBuf.ReadFrom(req.Body)
+						Expect(err).To(BeNil())
+					}
+					fmt.Fprintf(GinkgoWriter, "  Request body: %s", bodyBuf.String())
+
+					// TODO: Add check for shouldCreateProfile query parameter
+					Expect(req.URL.Query()["language"]).To(Equal([]string{"testString"}))
+					// Sleep a short time to support a timeout test
+					time.Sleep(100 * time.Millisecond)
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(201)
+					fmt.Fprintf(res, "%s", `{"displayName": "DisplayName", "active": true, "lockedUntil": 11, "emails": [{"value": "Value", "primary": false}], "meta": {"created": "2019-01-01T12:00:00.000Z", "lastModified": "2019-01-01T12:00:00.000Z", "resourceType": "ResourceType"}, "schemas": ["Schemas"], "name": {"givenName": "GivenName", "familyName": "FamilyName", "formatted": "Formatted"}, "userName": "UserName", "id": "ID", "status": "Status"}`)
+				}))
+			})
+			It(`Invoke StartSignUp successfully with retries`, func() {
+				appIDManagementService, serviceErr := appidmanagementv4.NewAppIDManagementV4(&appidmanagementv4.AppIDManagementV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(appIDManagementService).ToNot(BeNil())
+				appIDManagementService.EnableRetries(0, 0)
+
+				// Construct an instance of the CreateNewUserEmailsItem model
+				createNewUserEmailsItemModel := new(appidmanagementv4.CreateNewUserEmailsItem)
+				createNewUserEmailsItemModel.Value = core.StringPtr("user@mail.com")
+				createNewUserEmailsItemModel.Primary = core.BoolPtr(true)
+
+				// Construct an instance of the StartSignUpOptions model
+				startSignUpOptionsModel := new(appidmanagementv4.StartSignUpOptions)
+				startSignUpOptionsModel.TenantID = core.StringPtr("testString")
+				startSignUpOptionsModel.ShouldCreateProfile = core.BoolPtr(true)
+				startSignUpOptionsModel.Emails = []appidmanagementv4.CreateNewUserEmailsItem{*createNewUserEmailsItemModel}
+				startSignUpOptionsModel.Password = core.StringPtr("userPassword")
+				startSignUpOptionsModel.Active = core.BoolPtr(true)
+				startSignUpOptionsModel.LockedUntil = core.Int64Ptr(int64(1834879417592))
+				startSignUpOptionsModel.DisplayName = core.StringPtr("testString")
+				startSignUpOptionsModel.UserName = core.StringPtr("myUserName")
+				startSignUpOptionsModel.Status = core.StringPtr("PENDING")
+				startSignUpOptionsModel.Language = core.StringPtr("testString")
+				startSignUpOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with a Context to test a timeout error
+				ctx, cancelFunc := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc()
+				_, _, operationErr := appIDManagementService.StartSignUpWithContext(ctx, startSignUpOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+
+				// Disable retries and test again
+				appIDManagementService.DisableRetries()
+				result, response, operationErr := appIDManagementService.StartSignUp(startSignUpOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+				// Re-test the timeout error with retries disabled
+				ctx, cancelFunc2 := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc2()
+				_, _, operationErr = appIDManagementService.StartSignUpWithContext(ctx, startSignUpOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
 		Context(`Using mock server endpoint`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -3581,7 +4285,10 @@ var _ = Describe(`AppIDManagementV4`, func() {
 
 					// TODO: Add check for shouldCreateProfile query parameter
 					Expect(req.URL.Query()["language"]).To(Equal([]string{"testString"}))
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
+					fmt.Fprintf(res, "%s", `{"displayName": "DisplayName", "active": true, "lockedUntil": 11, "emails": [{"value": "Value", "primary": false}], "meta": {"created": "2019-01-01T12:00:00.000Z", "lastModified": "2019-01-01T12:00:00.000Z", "resourceType": "ResourceType"}, "schemas": ["Schemas"], "name": {"givenName": "GivenName", "familyName": "FamilyName", "formatted": "Formatted"}, "userName": "UserName", "id": "ID", "status": "Status"}`)
 				}))
 			})
 			It(`Invoke StartSignUp successfully`, func() {
@@ -3593,9 +4300,10 @@ var _ = Describe(`AppIDManagementV4`, func() {
 				Expect(appIDManagementService).ToNot(BeNil())
 
 				// Invoke operation with nil options model (negative test)
-				response, operationErr := appIDManagementService.StartSignUp(nil)
+				result, response, operationErr := appIDManagementService.StartSignUp(nil)
 				Expect(operationErr).NotTo(BeNil())
 				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
 
 				// Construct an instance of the CreateNewUserEmailsItem model
 				createNewUserEmailsItemModel := new(appidmanagementv4.CreateNewUserEmailsItem)
@@ -3609,14 +4317,19 @@ var _ = Describe(`AppIDManagementV4`, func() {
 				startSignUpOptionsModel.Emails = []appidmanagementv4.CreateNewUserEmailsItem{*createNewUserEmailsItemModel}
 				startSignUpOptionsModel.Password = core.StringPtr("userPassword")
 				startSignUpOptionsModel.Active = core.BoolPtr(true)
+				startSignUpOptionsModel.LockedUntil = core.Int64Ptr(int64(1834879417592))
+				startSignUpOptionsModel.DisplayName = core.StringPtr("testString")
 				startSignUpOptionsModel.UserName = core.StringPtr("myUserName")
+				startSignUpOptionsModel.Status = core.StringPtr("PENDING")
 				startSignUpOptionsModel.Language = core.StringPtr("testString")
 				startSignUpOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation with valid options model (positive test)
-				response, operationErr = appIDManagementService.StartSignUp(startSignUpOptionsModel)
+				result, response, operationErr = appIDManagementService.StartSignUp(startSignUpOptionsModel)
 				Expect(operationErr).To(BeNil())
 				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
 			})
 			It(`Invoke StartSignUp with error: Operation validation and request error`, func() {
 				appIDManagementService, serviceErr := appidmanagementv4.NewAppIDManagementV4(&appidmanagementv4.AppIDManagementV4Options{
@@ -3638,22 +4351,75 @@ var _ = Describe(`AppIDManagementV4`, func() {
 				startSignUpOptionsModel.Emails = []appidmanagementv4.CreateNewUserEmailsItem{*createNewUserEmailsItemModel}
 				startSignUpOptionsModel.Password = core.StringPtr("userPassword")
 				startSignUpOptionsModel.Active = core.BoolPtr(true)
+				startSignUpOptionsModel.LockedUntil = core.Int64Ptr(int64(1834879417592))
+				startSignUpOptionsModel.DisplayName = core.StringPtr("testString")
 				startSignUpOptionsModel.UserName = core.StringPtr("myUserName")
+				startSignUpOptionsModel.Status = core.StringPtr("PENDING")
 				startSignUpOptionsModel.Language = core.StringPtr("testString")
 				startSignUpOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Invoke operation with empty URL (negative test)
 				err := appIDManagementService.SetServiceURL("")
 				Expect(err).To(BeNil())
-				response, operationErr := appIDManagementService.StartSignUp(startSignUpOptionsModel)
+				result, response, operationErr := appIDManagementService.StartSignUp(startSignUpOptionsModel)
 				Expect(operationErr).ToNot(BeNil())
 				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
 				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
 				// Construct a second instance of the StartSignUpOptions model with no property values
 				startSignUpOptionsModelNew := new(appidmanagementv4.StartSignUpOptions)
 				// Invoke operation with invalid model (negative test)
-				response, operationErr = appIDManagementService.StartSignUp(startSignUpOptionsModelNew)
+				result, response, operationErr = appIDManagementService.StartSignUp(startSignUpOptionsModelNew)
 				Expect(operationErr).ToNot(BeNil())
 				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint with missing response body`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Set success status code with no respoonse body
+					res.WriteHeader(201)
+				}))
+			})
+			It(`Invoke StartSignUp successfully`, func() {
+				appIDManagementService, serviceErr := appidmanagementv4.NewAppIDManagementV4(&appidmanagementv4.AppIDManagementV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(appIDManagementService).ToNot(BeNil())
+
+				// Construct an instance of the CreateNewUserEmailsItem model
+				createNewUserEmailsItemModel := new(appidmanagementv4.CreateNewUserEmailsItem)
+				createNewUserEmailsItemModel.Value = core.StringPtr("user@mail.com")
+				createNewUserEmailsItemModel.Primary = core.BoolPtr(true)
+
+				// Construct an instance of the StartSignUpOptions model
+				startSignUpOptionsModel := new(appidmanagementv4.StartSignUpOptions)
+				startSignUpOptionsModel.TenantID = core.StringPtr("testString")
+				startSignUpOptionsModel.ShouldCreateProfile = core.BoolPtr(true)
+				startSignUpOptionsModel.Emails = []appidmanagementv4.CreateNewUserEmailsItem{*createNewUserEmailsItemModel}
+				startSignUpOptionsModel.Password = core.StringPtr("userPassword")
+				startSignUpOptionsModel.Active = core.BoolPtr(true)
+				startSignUpOptionsModel.LockedUntil = core.Int64Ptr(int64(1834879417592))
+				startSignUpOptionsModel.DisplayName = core.StringPtr("testString")
+				startSignUpOptionsModel.UserName = core.StringPtr("myUserName")
+				startSignUpOptionsModel.Status = core.StringPtr("PENDING")
+				startSignUpOptionsModel.Language = core.StringPtr("testString")
+				startSignUpOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation
+				result, response, operationErr := appIDManagementService.StartSignUp(startSignUpOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+
+				// Verify a nil result
+				Expect(result).To(BeNil())
 			})
 			AfterEach(func() {
 				testServer.Close()
@@ -3909,8 +4675,132 @@ var _ = Describe(`AppIDManagementV4`, func() {
 			})
 		})
 	})
+	Describe(`StartForgotPassword(startForgotPasswordOptions *StartForgotPasswordOptions) - Operation response error`, func() {
+		startForgotPasswordPath := "/management/v4/testString/cloud_directory/forgot_password"
+		Context(`Using mock server endpoint with invalid JSON response`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(startForgotPasswordPath))
+					Expect(req.Method).To(Equal("POST"))
+					Expect(req.URL.Query()["language"]).To(Equal([]string{"testString"}))
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, `} this is not valid json {`)
+				}))
+			})
+			It(`Invoke StartForgotPassword with error: Operation response processing error`, func() {
+				appIDManagementService, serviceErr := appidmanagementv4.NewAppIDManagementV4(&appidmanagementv4.AppIDManagementV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(appIDManagementService).ToNot(BeNil())
+
+				// Construct an instance of the StartForgotPasswordOptions model
+				startForgotPasswordOptionsModel := new(appidmanagementv4.StartForgotPasswordOptions)
+				startForgotPasswordOptionsModel.TenantID = core.StringPtr("testString")
+				startForgotPasswordOptionsModel.User = core.StringPtr("testString")
+				startForgotPasswordOptionsModel.Language = core.StringPtr("testString")
+				startForgotPasswordOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Expect response parsing to fail since we are receiving a text/plain response
+				result, response, operationErr := appIDManagementService.StartForgotPassword(startForgotPasswordOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+
+				// Enable retries and test again
+				appIDManagementService.EnableRetries(0, 0)
+				result, response, operationErr = appIDManagementService.StartForgotPassword(startForgotPasswordOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
 	Describe(`StartForgotPassword(startForgotPasswordOptions *StartForgotPasswordOptions)`, func() {
 		startForgotPasswordPath := "/management/v4/testString/cloud_directory/forgot_password"
+		Context(`Using mock server endpoint with timeout`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(startForgotPasswordPath))
+					Expect(req.Method).To(Equal("POST"))
+
+					// For gzip-disabled operation, verify Content-Encoding is not set.
+					Expect(req.Header.Get("Content-Encoding")).To(BeEmpty())
+
+					// If there is a body, then make sure we can read it
+					bodyBuf := new(bytes.Buffer)
+					if req.Header.Get("Content-Encoding") == "gzip" {
+						body, err := core.NewGzipDecompressionReader(req.Body)
+						Expect(err).To(BeNil())
+						_, err = bodyBuf.ReadFrom(body)
+						Expect(err).To(BeNil())
+					} else {
+						_, err := bodyBuf.ReadFrom(req.Body)
+						Expect(err).To(BeNil())
+					}
+					fmt.Fprintf(GinkgoWriter, "  Request body: %s", bodyBuf.String())
+
+					Expect(req.URL.Query()["language"]).To(Equal([]string{"testString"}))
+					// Sleep a short time to support a timeout test
+					time.Sleep(100 * time.Millisecond)
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"displayName": "DisplayName", "active": true, "lockedUntil": 11, "emails": [{"value": "Value", "primary": false}], "meta": {"created": "2019-01-01T12:00:00.000Z", "lastModified": "2019-01-01T12:00:00.000Z", "resourceType": "ResourceType"}, "schemas": ["Schemas"], "name": {"givenName": "GivenName", "familyName": "FamilyName", "formatted": "Formatted"}, "userName": "UserName", "id": "ID", "status": "Status"}`)
+				}))
+			})
+			It(`Invoke StartForgotPassword successfully with retries`, func() {
+				appIDManagementService, serviceErr := appidmanagementv4.NewAppIDManagementV4(&appidmanagementv4.AppIDManagementV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(appIDManagementService).ToNot(BeNil())
+				appIDManagementService.EnableRetries(0, 0)
+
+				// Construct an instance of the StartForgotPasswordOptions model
+				startForgotPasswordOptionsModel := new(appidmanagementv4.StartForgotPasswordOptions)
+				startForgotPasswordOptionsModel.TenantID = core.StringPtr("testString")
+				startForgotPasswordOptionsModel.User = core.StringPtr("testString")
+				startForgotPasswordOptionsModel.Language = core.StringPtr("testString")
+				startForgotPasswordOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with a Context to test a timeout error
+				ctx, cancelFunc := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc()
+				_, _, operationErr := appIDManagementService.StartForgotPasswordWithContext(ctx, startForgotPasswordOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+
+				// Disable retries and test again
+				appIDManagementService.DisableRetries()
+				result, response, operationErr := appIDManagementService.StartForgotPassword(startForgotPasswordOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+				// Re-test the timeout error with retries disabled
+				ctx, cancelFunc2 := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc2()
+				_, _, operationErr = appIDManagementService.StartForgotPasswordWithContext(ctx, startForgotPasswordOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
 		Context(`Using mock server endpoint`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -3937,7 +4827,10 @@ var _ = Describe(`AppIDManagementV4`, func() {
 					fmt.Fprintf(GinkgoWriter, "  Request body: %s", bodyBuf.String())
 
 					Expect(req.URL.Query()["language"]).To(Equal([]string{"testString"}))
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"displayName": "DisplayName", "active": true, "lockedUntil": 11, "emails": [{"value": "Value", "primary": false}], "meta": {"created": "2019-01-01T12:00:00.000Z", "lastModified": "2019-01-01T12:00:00.000Z", "resourceType": "ResourceType"}, "schemas": ["Schemas"], "name": {"givenName": "GivenName", "familyName": "FamilyName", "formatted": "Formatted"}, "userName": "UserName", "id": "ID", "status": "Status"}`)
 				}))
 			})
 			It(`Invoke StartForgotPassword successfully`, func() {
@@ -3949,9 +4842,10 @@ var _ = Describe(`AppIDManagementV4`, func() {
 				Expect(appIDManagementService).ToNot(BeNil())
 
 				// Invoke operation with nil options model (negative test)
-				response, operationErr := appIDManagementService.StartForgotPassword(nil)
+				result, response, operationErr := appIDManagementService.StartForgotPassword(nil)
 				Expect(operationErr).NotTo(BeNil())
 				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
 
 				// Construct an instance of the StartForgotPasswordOptions model
 				startForgotPasswordOptionsModel := new(appidmanagementv4.StartForgotPasswordOptions)
@@ -3961,9 +4855,11 @@ var _ = Describe(`AppIDManagementV4`, func() {
 				startForgotPasswordOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation with valid options model (positive test)
-				response, operationErr = appIDManagementService.StartForgotPassword(startForgotPasswordOptionsModel)
+				result, response, operationErr = appIDManagementService.StartForgotPassword(startForgotPasswordOptionsModel)
 				Expect(operationErr).To(BeNil())
 				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
 			})
 			It(`Invoke StartForgotPassword with error: Operation validation and request error`, func() {
 				appIDManagementService, serviceErr := appidmanagementv4.NewAppIDManagementV4(&appidmanagementv4.AppIDManagementV4Options{
@@ -3982,16 +4878,54 @@ var _ = Describe(`AppIDManagementV4`, func() {
 				// Invoke operation with empty URL (negative test)
 				err := appIDManagementService.SetServiceURL("")
 				Expect(err).To(BeNil())
-				response, operationErr := appIDManagementService.StartForgotPassword(startForgotPasswordOptionsModel)
+				result, response, operationErr := appIDManagementService.StartForgotPassword(startForgotPasswordOptionsModel)
 				Expect(operationErr).ToNot(BeNil())
 				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
 				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
 				// Construct a second instance of the StartForgotPasswordOptions model with no property values
 				startForgotPasswordOptionsModelNew := new(appidmanagementv4.StartForgotPasswordOptions)
 				// Invoke operation with invalid model (negative test)
-				response, operationErr = appIDManagementService.StartForgotPassword(startForgotPasswordOptionsModelNew)
+				result, response, operationErr = appIDManagementService.StartForgotPassword(startForgotPasswordOptionsModelNew)
 				Expect(operationErr).ToNot(BeNil())
 				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint with missing response body`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Set success status code with no respoonse body
+					res.WriteHeader(200)
+				}))
+			})
+			It(`Invoke StartForgotPassword successfully`, func() {
+				appIDManagementService, serviceErr := appidmanagementv4.NewAppIDManagementV4(&appidmanagementv4.AppIDManagementV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(appIDManagementService).ToNot(BeNil())
+
+				// Construct an instance of the StartForgotPasswordOptions model
+				startForgotPasswordOptionsModel := new(appidmanagementv4.StartForgotPasswordOptions)
+				startForgotPasswordOptionsModel.TenantID = core.StringPtr("testString")
+				startForgotPasswordOptionsModel.User = core.StringPtr("testString")
+				startForgotPasswordOptionsModel.Language = core.StringPtr("testString")
+				startForgotPasswordOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation
+				result, response, operationErr := appIDManagementService.StartForgotPassword(startForgotPasswordOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+
+				// Verify a nil result
+				Expect(result).To(BeNil())
 			})
 			AfterEach(func() {
 				testServer.Close()
@@ -4247,8 +5181,136 @@ var _ = Describe(`AppIDManagementV4`, func() {
 			})
 		})
 	})
+	Describe(`ChangePassword(changePasswordOptions *ChangePasswordOptions) - Operation response error`, func() {
+		changePasswordPath := "/management/v4/testString/cloud_directory/change_password"
+		Context(`Using mock server endpoint with invalid JSON response`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(changePasswordPath))
+					Expect(req.Method).To(Equal("POST"))
+					Expect(req.URL.Query()["language"]).To(Equal([]string{"testString"}))
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, `} this is not valid json {`)
+				}))
+			})
+			It(`Invoke ChangePassword with error: Operation response processing error`, func() {
+				appIDManagementService, serviceErr := appidmanagementv4.NewAppIDManagementV4(&appidmanagementv4.AppIDManagementV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(appIDManagementService).ToNot(BeNil())
+
+				// Construct an instance of the ChangePasswordOptions model
+				changePasswordOptionsModel := new(appidmanagementv4.ChangePasswordOptions)
+				changePasswordOptionsModel.TenantID = core.StringPtr("testString")
+				changePasswordOptionsModel.NewPassword = core.StringPtr("testString")
+				changePasswordOptionsModel.UUID = core.StringPtr("testString")
+				changePasswordOptionsModel.ChangedIPAddress = core.StringPtr("testString")
+				changePasswordOptionsModel.Language = core.StringPtr("testString")
+				changePasswordOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Expect response parsing to fail since we are receiving a text/plain response
+				result, response, operationErr := appIDManagementService.ChangePassword(changePasswordOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+
+				// Enable retries and test again
+				appIDManagementService.EnableRetries(0, 0)
+				result, response, operationErr = appIDManagementService.ChangePassword(changePasswordOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
 	Describe(`ChangePassword(changePasswordOptions *ChangePasswordOptions)`, func() {
 		changePasswordPath := "/management/v4/testString/cloud_directory/change_password"
+		Context(`Using mock server endpoint with timeout`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(changePasswordPath))
+					Expect(req.Method).To(Equal("POST"))
+
+					// For gzip-disabled operation, verify Content-Encoding is not set.
+					Expect(req.Header.Get("Content-Encoding")).To(BeEmpty())
+
+					// If there is a body, then make sure we can read it
+					bodyBuf := new(bytes.Buffer)
+					if req.Header.Get("Content-Encoding") == "gzip" {
+						body, err := core.NewGzipDecompressionReader(req.Body)
+						Expect(err).To(BeNil())
+						_, err = bodyBuf.ReadFrom(body)
+						Expect(err).To(BeNil())
+					} else {
+						_, err := bodyBuf.ReadFrom(req.Body)
+						Expect(err).To(BeNil())
+					}
+					fmt.Fprintf(GinkgoWriter, "  Request body: %s", bodyBuf.String())
+
+					Expect(req.URL.Query()["language"]).To(Equal([]string{"testString"}))
+					// Sleep a short time to support a timeout test
+					time.Sleep(100 * time.Millisecond)
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"displayName": "DisplayName", "active": true, "lockedUntil": 11, "emails": [{"value": "Value", "primary": false}], "meta": {"created": "2019-01-01T12:00:00.000Z", "lastModified": "2019-01-01T12:00:00.000Z", "resourceType": "ResourceType"}, "schemas": ["Schemas"], "name": {"givenName": "GivenName", "familyName": "FamilyName", "formatted": "Formatted"}, "userName": "UserName", "id": "ID", "status": "Status"}`)
+				}))
+			})
+			It(`Invoke ChangePassword successfully with retries`, func() {
+				appIDManagementService, serviceErr := appidmanagementv4.NewAppIDManagementV4(&appidmanagementv4.AppIDManagementV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(appIDManagementService).ToNot(BeNil())
+				appIDManagementService.EnableRetries(0, 0)
+
+				// Construct an instance of the ChangePasswordOptions model
+				changePasswordOptionsModel := new(appidmanagementv4.ChangePasswordOptions)
+				changePasswordOptionsModel.TenantID = core.StringPtr("testString")
+				changePasswordOptionsModel.NewPassword = core.StringPtr("testString")
+				changePasswordOptionsModel.UUID = core.StringPtr("testString")
+				changePasswordOptionsModel.ChangedIPAddress = core.StringPtr("testString")
+				changePasswordOptionsModel.Language = core.StringPtr("testString")
+				changePasswordOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with a Context to test a timeout error
+				ctx, cancelFunc := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc()
+				_, _, operationErr := appIDManagementService.ChangePasswordWithContext(ctx, changePasswordOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+
+				// Disable retries and test again
+				appIDManagementService.DisableRetries()
+				result, response, operationErr := appIDManagementService.ChangePassword(changePasswordOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+				// Re-test the timeout error with retries disabled
+				ctx, cancelFunc2 := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc2()
+				_, _, operationErr = appIDManagementService.ChangePasswordWithContext(ctx, changePasswordOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
 		Context(`Using mock server endpoint`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -4275,7 +5337,10 @@ var _ = Describe(`AppIDManagementV4`, func() {
 					fmt.Fprintf(GinkgoWriter, "  Request body: %s", bodyBuf.String())
 
 					Expect(req.URL.Query()["language"]).To(Equal([]string{"testString"}))
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"displayName": "DisplayName", "active": true, "lockedUntil": 11, "emails": [{"value": "Value", "primary": false}], "meta": {"created": "2019-01-01T12:00:00.000Z", "lastModified": "2019-01-01T12:00:00.000Z", "resourceType": "ResourceType"}, "schemas": ["Schemas"], "name": {"givenName": "GivenName", "familyName": "FamilyName", "formatted": "Formatted"}, "userName": "UserName", "id": "ID", "status": "Status"}`)
 				}))
 			})
 			It(`Invoke ChangePassword successfully`, func() {
@@ -4287,9 +5352,10 @@ var _ = Describe(`AppIDManagementV4`, func() {
 				Expect(appIDManagementService).ToNot(BeNil())
 
 				// Invoke operation with nil options model (negative test)
-				response, operationErr := appIDManagementService.ChangePassword(nil)
+				result, response, operationErr := appIDManagementService.ChangePassword(nil)
 				Expect(operationErr).NotTo(BeNil())
 				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
 
 				// Construct an instance of the ChangePasswordOptions model
 				changePasswordOptionsModel := new(appidmanagementv4.ChangePasswordOptions)
@@ -4301,9 +5367,11 @@ var _ = Describe(`AppIDManagementV4`, func() {
 				changePasswordOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation with valid options model (positive test)
-				response, operationErr = appIDManagementService.ChangePassword(changePasswordOptionsModel)
+				result, response, operationErr = appIDManagementService.ChangePassword(changePasswordOptionsModel)
 				Expect(operationErr).To(BeNil())
 				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
 			})
 			It(`Invoke ChangePassword with error: Operation validation and request error`, func() {
 				appIDManagementService, serviceErr := appidmanagementv4.NewAppIDManagementV4(&appidmanagementv4.AppIDManagementV4Options{
@@ -4324,16 +5392,56 @@ var _ = Describe(`AppIDManagementV4`, func() {
 				// Invoke operation with empty URL (negative test)
 				err := appIDManagementService.SetServiceURL("")
 				Expect(err).To(BeNil())
-				response, operationErr := appIDManagementService.ChangePassword(changePasswordOptionsModel)
+				result, response, operationErr := appIDManagementService.ChangePassword(changePasswordOptionsModel)
 				Expect(operationErr).ToNot(BeNil())
 				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
 				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
 				// Construct a second instance of the ChangePasswordOptions model with no property values
 				changePasswordOptionsModelNew := new(appidmanagementv4.ChangePasswordOptions)
 				// Invoke operation with invalid model (negative test)
-				response, operationErr = appIDManagementService.ChangePassword(changePasswordOptionsModelNew)
+				result, response, operationErr = appIDManagementService.ChangePassword(changePasswordOptionsModelNew)
 				Expect(operationErr).ToNot(BeNil())
 				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint with missing response body`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Set success status code with no respoonse body
+					res.WriteHeader(200)
+				}))
+			})
+			It(`Invoke ChangePassword successfully`, func() {
+				appIDManagementService, serviceErr := appidmanagementv4.NewAppIDManagementV4(&appidmanagementv4.AppIDManagementV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(appIDManagementService).ToNot(BeNil())
+
+				// Construct an instance of the ChangePasswordOptions model
+				changePasswordOptionsModel := new(appidmanagementv4.ChangePasswordOptions)
+				changePasswordOptionsModel.TenantID = core.StringPtr("testString")
+				changePasswordOptionsModel.NewPassword = core.StringPtr("testString")
+				changePasswordOptionsModel.UUID = core.StringPtr("testString")
+				changePasswordOptionsModel.ChangedIPAddress = core.StringPtr("testString")
+				changePasswordOptionsModel.Language = core.StringPtr("testString")
+				changePasswordOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation
+				result, response, operationErr := appIDManagementService.ChangePassword(changePasswordOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+
+				// Verify a nil result
+				Expect(result).To(BeNil())
 			})
 			AfterEach(func() {
 				testServer.Close()
@@ -19688,14 +20796,20 @@ var _ = Describe(`AppIDManagementV4`, func() {
 				createCloudDirectoryUserOptionsModel.SetEmails([]appidmanagementv4.CreateNewUserEmailsItem{*createNewUserEmailsItemModel})
 				createCloudDirectoryUserOptionsModel.SetPassword("userPassword")
 				createCloudDirectoryUserOptionsModel.SetActive(true)
+				createCloudDirectoryUserOptionsModel.SetLockedUntil(int64(1834879417592))
+				createCloudDirectoryUserOptionsModel.SetDisplayName("testString")
 				createCloudDirectoryUserOptionsModel.SetUserName("myUserName")
+				createCloudDirectoryUserOptionsModel.SetStatus("PENDING")
 				createCloudDirectoryUserOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(createCloudDirectoryUserOptionsModel).ToNot(BeNil())
 				Expect(createCloudDirectoryUserOptionsModel.TenantID).To(Equal(core.StringPtr("testString")))
 				Expect(createCloudDirectoryUserOptionsModel.Emails).To(Equal([]appidmanagementv4.CreateNewUserEmailsItem{*createNewUserEmailsItemModel}))
 				Expect(createCloudDirectoryUserOptionsModel.Password).To(Equal(core.StringPtr("userPassword")))
 				Expect(createCloudDirectoryUserOptionsModel.Active).To(Equal(core.BoolPtr(true)))
+				Expect(createCloudDirectoryUserOptionsModel.LockedUntil).To(Equal(core.Int64Ptr(int64(1834879417592))))
+				Expect(createCloudDirectoryUserOptionsModel.DisplayName).To(Equal(core.StringPtr("testString")))
 				Expect(createCloudDirectoryUserOptionsModel.UserName).To(Equal(core.StringPtr("myUserName")))
+				Expect(createCloudDirectoryUserOptionsModel.Status).To(Equal(core.StringPtr("PENDING")))
 				Expect(createCloudDirectoryUserOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
 			It(`Invoke NewCreateNewUserEmailsItem successfully`, func() {
@@ -21012,7 +22126,10 @@ var _ = Describe(`AppIDManagementV4`, func() {
 				startSignUpOptionsModel.SetEmails([]appidmanagementv4.CreateNewUserEmailsItem{*createNewUserEmailsItemModel})
 				startSignUpOptionsModel.SetPassword("userPassword")
 				startSignUpOptionsModel.SetActive(true)
+				startSignUpOptionsModel.SetLockedUntil(int64(1834879417592))
+				startSignUpOptionsModel.SetDisplayName("testString")
 				startSignUpOptionsModel.SetUserName("myUserName")
+				startSignUpOptionsModel.SetStatus("PENDING")
 				startSignUpOptionsModel.SetLanguage("testString")
 				startSignUpOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(startSignUpOptionsModel).ToNot(BeNil())
@@ -21021,7 +22138,10 @@ var _ = Describe(`AppIDManagementV4`, func() {
 				Expect(startSignUpOptionsModel.Emails).To(Equal([]appidmanagementv4.CreateNewUserEmailsItem{*createNewUserEmailsItemModel}))
 				Expect(startSignUpOptionsModel.Password).To(Equal(core.StringPtr("userPassword")))
 				Expect(startSignUpOptionsModel.Active).To(Equal(core.BoolPtr(true)))
+				Expect(startSignUpOptionsModel.LockedUntil).To(Equal(core.Int64Ptr(int64(1834879417592))))
+				Expect(startSignUpOptionsModel.DisplayName).To(Equal(core.StringPtr("testString")))
 				Expect(startSignUpOptionsModel.UserName).To(Equal(core.StringPtr("myUserName")))
+				Expect(startSignUpOptionsModel.Status).To(Equal(core.StringPtr("PENDING")))
 				Expect(startSignUpOptionsModel.Language).To(Equal(core.StringPtr("testString")))
 				Expect(startSignUpOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
@@ -21076,17 +22196,23 @@ var _ = Describe(`AppIDManagementV4`, func() {
 				updateCloudDirectoryUserOptionsModel.SetTenantID("testString")
 				updateCloudDirectoryUserOptionsModel.SetUserID("testString")
 				updateCloudDirectoryUserOptionsModel.SetEmails([]appidmanagementv4.CreateNewUserEmailsItem{*createNewUserEmailsItemModel})
-				updateCloudDirectoryUserOptionsModel.SetActive(true)
+				updateCloudDirectoryUserOptionsModel.SetStatus("testString")
+				updateCloudDirectoryUserOptionsModel.SetDisplayName("testString")
 				updateCloudDirectoryUserOptionsModel.SetUserName("myUserName")
 				updateCloudDirectoryUserOptionsModel.SetPassword("userPassword")
+				updateCloudDirectoryUserOptionsModel.SetActive(false)
+				updateCloudDirectoryUserOptionsModel.SetLockedUntil(int64(1834879417592))
 				updateCloudDirectoryUserOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(updateCloudDirectoryUserOptionsModel).ToNot(BeNil())
 				Expect(updateCloudDirectoryUserOptionsModel.TenantID).To(Equal(core.StringPtr("testString")))
 				Expect(updateCloudDirectoryUserOptionsModel.UserID).To(Equal(core.StringPtr("testString")))
 				Expect(updateCloudDirectoryUserOptionsModel.Emails).To(Equal([]appidmanagementv4.CreateNewUserEmailsItem{*createNewUserEmailsItemModel}))
-				Expect(updateCloudDirectoryUserOptionsModel.Active).To(Equal(core.BoolPtr(true)))
+				Expect(updateCloudDirectoryUserOptionsModel.Status).To(Equal(core.StringPtr("testString")))
+				Expect(updateCloudDirectoryUserOptionsModel.DisplayName).To(Equal(core.StringPtr("testString")))
 				Expect(updateCloudDirectoryUserOptionsModel.UserName).To(Equal(core.StringPtr("myUserName")))
 				Expect(updateCloudDirectoryUserOptionsModel.Password).To(Equal(core.StringPtr("userPassword")))
+				Expect(updateCloudDirectoryUserOptionsModel.Active).To(Equal(core.BoolPtr(false)))
+				Expect(updateCloudDirectoryUserOptionsModel.LockedUntil).To(Equal(core.Int64Ptr(int64(1834879417592))))
 				Expect(updateCloudDirectoryUserOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
 			It(`Invoke NewUpdateExtensionActiveOptions successfully`, func() {


### PR DESCRIPTION
## PR summary
Add user object properties to getUser call

In addition, it adds couple missing fields to Create and Update methods, to make them consistent

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?  
User payload did not list any properties and so generated go sdk was only providing raw payload

## What is the new behavior?  
Return User object with all fields included

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->